### PR TITLE
docs: rewrite the developer docs around the post-OpenHuman architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Not ready to sign in? `medulla --mock` runs a full offline demo, with no account
 
 Prebuilt binaries ship for Linux (x86_64, aarch64), macOS (Apple Silicon), and Windows (x86_64). Building from source, pinning a version, and embedding the SDK are covered in [Getting Started](https://tinyhumans.gitbook.io/medulla/developers/getting-started).
 
+## No tmux, no multi-agent wrapper
+
+Running a lot of agents has meant one of two workarounds: split the terminal into panes and be the scheduler yourself, or wrap the harnesses in another agent and hope it can read everything they produce. Medulla is one process, in one terminal, built for the job instead.
+
+Opening another agent is `Ctrl-T` — pick a harness or a shell, pick a directory, it is running. There is no ceiling on how many you keep open. Each gets its own terminal, kept live in the background whether or not it is the one on screen, and Medulla reads all of them for the things that need a human: a permission prompt, a blocking error, a dead session, a turn finished and waiting on review. Those arrive as `⚠ 3 waiting on you`, not as three panes you were supposed to have been watching.
+
 ## What you get
 
 Your whole fleet, legible. One lane per agent, live. You can see what each agent is doing, answer the one that has a question, and cancel the one that has gone wrong, without losing your place in everything else.

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -222,9 +222,14 @@ with `medulla init` and registered with `medulla workspace add`.
 ## Provider
 
 A coding-assistant CLI: the same axis as an agent's **harness** type, seen from
-the process end. The three supported providers are `claude` (Claude Code),
+the process end. The three coding-CLI providers are `claude` (Claude Code),
 `codex` (OpenAI Codex), and `opencode`. The daemon spawns the CLI as a subprocess
 and communicates over ACP or legacy JSONL.
+
+Two more providers sit outside that coding-CLI set: `openhuman`, the in-process
+harness that runs an agent turn inside the `medulla` process instead of
+spawning one (see **Harness** above), and `shell`, a plain interactive shell
+that is never dispatchable or auto-detected.
 
 A provider is chosen together with a **transport**, and the pair is named by one
 word, a **flavor**. `codex` is Codex on its CLI; `codex-server` is the same

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -46,6 +46,8 @@ that CLI:
 | Codex          | ACP over stdio                                                  |
 | `codex-server` | JSON-RPC over stdio to a shared, long-lived `codex app-server`  |
 | OpenCode       | ACP over stdio                                                  |
+| OpenHuman      | In-process: no binary spawned, no transport. The wire value is `HarnessProvider::Openhuman`; the agent turn runs inside the `medulla` process on the vendored `tinyagents` crate with Medulla's own tools ([`src/sdk/src/daemon/providers/local/mod.rs`](../src/sdk/src/daemon/providers/local/mod.rs)). Never auto-selected by provider detection — a node reaches it only by naming it. |
+| Shell          | None: a plain interactive shell (`bash`, `zsh`, whatever `$SHELL` names), not a coding agent. Never detected as an available provider and never dispatchable; it exists so an operator can open a terminal beside their agents in the same pane, host, and working directory. |
 
 `codex-server` is a **flavor** of Codex rather than a separate harness type: it
 authenticates, bills, and configures as Codex and differs only in that one

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -99,6 +99,13 @@ wants work done, the **hub** delivers a `TaskRequest` (carrying a `task_id`,
 **worker** and collects the `TaskOutcome`. It is the outbound half of the
 daemon's task loop.
 
+The hub also carries the **workflow plane** (`src/sdk/src/hub/plane/`): the wire
+contract with the Medulla orchestration backend for saved workflow graphs —
+Socket.IO shapes and `medulla:*` event names (`payloads.rs`) — and the
+store-side `WorkflowBridge` trait (`bridge.rs`) an embedding host installs to
+answer them. It used to be re-exported from the embedded OpenHuman core; with
+that core removed, Medulla is the only host left that speaks it.
+
 ## Cycle
 
 One orchestrator turn: **user input → reasoning → tool calls → reply**. A cycle

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -46,7 +46,7 @@ that CLI:
 | Codex          | ACP over stdio                                                  |
 | `codex-server` | JSON-RPC over stdio to a shared, long-lived `codex app-server`  |
 | OpenCode       | ACP over stdio                                                  |
-| OpenHuman      | In-process: no binary spawned, no transport. The wire value is `HarnessProvider::Openhuman`; the agent turn runs inside the `medulla` process on the vendored `tinyagents` crate with Medulla's own tools ([`src/sdk/src/daemon/providers/local/mod.rs`](../src/sdk/src/daemon/providers/local/mod.rs)). Never auto-selected by provider detection — a node reaches it only by naming it. |
+| OpenHuman      | In-process: no binary spawned, no transport. The wire value is `HarnessProvider::Openhuman`; the agent turn runs inside the `medulla` process on the vendored `tinyagents` crate with Medulla's own tools (`src/sdk/src/daemon/providers/local/mod.rs`). Never auto-selected by provider detection — a node reaches it only by naming it. |
 | Shell          | None: a plain interactive shell (`bash`, `zsh`, whatever `$SHELL` names), not a coding agent. Never detected as an available provider and never dispatchable; it exists so an operator can open a terminal beside their agents in the same pane, host, and working directory. |
 
 `codex-server` is a **flavor** of Codex rather than a separate harness type: it

--- a/docs/attribution-proxy.md
+++ b/docs/attribution-proxy.md
@@ -88,14 +88,17 @@ All three spawned harnesses are covered. OpenCode is accepted as a
 `customHarnesses` base even though it can reach OpenRouter natively, because that
 native path is exactly the one this proxy needs to take over.
 
-The embedded OpenHuman core is covered too, by a different mechanism. It is not a
-child process, so there is no environment to inject into and nothing to scrub:
-Medulla resolves the preset's key, exchanges it for a loopback token, and hands
-the core the mount and the token as a *per-call* route on
-`inference_agent_chat`. The core applies that route to the turn's own in-memory
-configuration and never persists it, so borrowing an endpoint for one node does
-not repoint the account's own inference. As with a spawned harness, the core is
-given the token and never the OpenRouter key.
+The local in-process harness is covered too, by the same mechanism through a
+different call shape. Naming `openhuman` as a node's harness no longer dispatches
+into a separate core; it runs the turn in-process on the vendored `tinyagents`
+loop, with Medulla's own tools. That turn is not a child process, so there is no
+environment to inject into and nothing to scrub: Medulla resolves the preset's
+key, exchanges it for a loopback token, and hands the turn the mount and the
+token directly as the route it calls inference on. Unlike a spawned harness, this
+one has no ambient inference configuration to fall back to — with no router
+preset naming an endpoint and a model, the turn refuses to run rather than
+resolving one some other way. As with a spawned harness, the turn is given the
+token and never the OpenRouter key.
 
 One limitation applies. Medulla injects environment variables at the spawn seam
 and never writes a harness's own configuration file. A harness you have

--- a/docs/e2e-live-harness.md
+++ b/docs/e2e-live-harness.md
@@ -57,8 +57,8 @@ routed at the mock and which wire dialect it lands on.
 | `e2e/coordination/Dockerfile` | the harness image: a rust build stage layered onto that base |
 | `e2e/coordination/build-image.sh` | build (and optionally push) either image |
 | `e2e/coordination/run-docker.sh` | build + run the whole harness in a container |
-| `examples/mock_link_forwarder.rs` | blind UDP forwarder implementing protocol §5 rules 1-8 |
-| `examples/coordination_owner.rs` | owner-side driver: enrolls pairs, serves legs, prints terminal frame JSON |
+| `src/sdk/examples/mock_link_forwarder.rs` | blind UDP forwarder implementing protocol §5 rules 1-8 |
+| `src/sdk/examples/coordination_owner/main.rs` | owner-side driver: enrolls pairs, serves legs, prints terminal frame JSON |
 
 ## Running
 

--- a/docs/e2e-live-harness.md
+++ b/docs/e2e-live-harness.md
@@ -11,8 +11,8 @@ One end-to-end round trip over the **host link** (`docs/host-link-protocol.md`),
 with no real keys and no network egress:
 
 ```
-owner driver (examples/coordination_owner.rs; a real medulla-link endpoint)
-  → mock link forwarder (examples/mock_link_forwarder.rs; blind UDP, §5)
+owner driver (src/sdk/examples/coordination_owner/main.rs; a real medulla-link endpoint)
+  → mock link forwarder (src/sdk/examples/mock_link_forwarder.rs; blind UDP, §5)
     → medulla daemon (real binary, `--providers <harness>`, the host end)
       → the real coding CLI (spawned by the daemon as its provider)
         → mock LLM (e2e/coordination/mock_llm.py)

--- a/docs/plans/harness-workflow-skills.md
+++ b/docs/plans/harness-workflow-skills.md
@@ -26,7 +26,7 @@ Facts this plan rests on, each checked against the tree at `11351b34`:
 - **Declared inputs are already on the listing view.** `WorkflowSummary.inputs`
   (`src/sdk/src/workflows/types/workflow.rs:176`) carries `Vec<WorkflowInput>` —
   `name`, `type`, `description`, `required`, `default`
-  (`vendor/openhuman/vendor/tinyflows/src/model/inputs.rs:112`). Rendering a skill needs
+  (`vendor/tinyflows/src/model/inputs.rs:112`). Rendering a skill needs
   only `workflow_list`, not a graph fetch.
 - **Tool-surface gating already exists.** `ToolMode::{Full,Propose}` +
   `MEDULLA_WORKFLOW_TOOLS` (`src/sdk/src/workflows/mcp/evolve.rs`) withhold verbs from

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -1,110 +1,77 @@
 # Vendored dependencies
 
-Some upstream crates are consumed as git submodules under `vendor/` rather than
-from crates.io. The workspace `exclude = ["vendor"]` keeps them out of `members`,
-so they carry their own lints and tests instead of joining this repository's CI
-gates.
+Three upstream crates are consumed as git submodules under `vendor/` rather than
+from crates.io. The workspace `exclude = ["vendor", "worktrees"]` keeps them out
+of `members`, so they carry their own lints and tests instead of joining this
+repository's CI gates.
 
 | Submodule | Upstream | Consumed as |
 | --- | --- | --- |
-| `vendor/tinyplace` | `tinyhumansai/tiny.place` | path dependency |
-| `vendor/tinycortex` | `tinyhumansai/tinycortex` | path dependency |
-| `vendor/tinyflows` | `tinyhumansai/tinyflows` | registry coordinate + `[patch.crates-io]` |
+| `vendor/tinyagents` | `tinyhumansai/tinyagents` | registry coordinate `2.1` + `[patch.crates-io]` |
+| `vendor/tinyflows` | `tinyhumansai/tinyflows` | registry coordinate `0.8` + `[patch.crates-io]` |
+| `vendor/tinyhumans-sdk` | `tinyhumansai/sdk` | path dependency (no registry coordinate) |
 
-Initialize everything with:
+Initialize with:
 
 ```sh
-git submodule update --init --recursive
+bash scripts/init-submodules.sh
 ```
 
-## tinyflows
+not `git submodule update --init --recursive`. `vendor/tinyagents` carries a
+`wiki` documentation submodule that nothing here compiles, and `--recursive`
+descends unconditionally. The script is also the one place the vendored set is
+written down, and must stay in lockstep with the root manifest's
+`[patch.crates-io]` table.
 
-`tinyflows` is the DAG workflow engine behind the `workflows` feature. It is
-declared in the root `Cargo.toml` as a *registry* dependency and redirected to
-the submodule:
+All three submodules are self-contained: none declares a path or git dependency
+of its own, and none carries code submodules of its own. `.gitmodules` uses
+HTTPS URLs so CI clones them without a deploy key.
 
-```toml
-[workspace.dependencies]
-tinyflows = { version = "0.5", features = ["mock"] }
+## What each one is for
 
-[patch.crates-io]
-tinyflows = { path = "vendor/tinyflows" }
-```
+`tinyagents` is the agent harness — the bounded model/tool loop that
+`src/sdk/src/daemon/providers/local/` runs in-process for the `openhuman`
+harness provider, replacing what used to be an `inference_agent_chat` RPC into
+the embedded core. The `sqlite` feature brings `tinyagents::session`, the durable
+store behind `src/sdk/src/agent/history/`; `tools` brings the builtin tool family
+the loop dispatches. Neither is on by default in the crate.
 
-This is the same shape the sibling `openhuman` host uses. The indirection exists
-because crates.io lags the branch we track (the published maximum is `0.3.0`
-while the pinned tree reports `0.5.1`), so a plain registry dependency would not
-resolve to the code we build against. Keeping the registry coordinate (rather
-than a bare path dependency) means the two hosts share one pin and one upgrade
-cadence.
+`tinyflows` is the DAG workflow engine behind the SDK's `flows` feature, reached
+through the adapter seam in `src/sdk/src/flow_engine/`. Its `mock` feature is a
+normal dependency feature rather than a dev-only one: the authoring surface
+dry-runs graphs against the engine's deterministic capability stand-ins in
+ordinary builds, not just in tests. `host-caps` and `store` supply the host
+capability set and the graph store.
 
-**Pinned commit:** `fb24363aea921f957958bc8f4aeb5b0a244e41c7` (`v0.3.0-37-gfb24363`),
-matching `openhuman`.
+`tinyhumans-sdk` is the shared TinyHumans HTTP transport (`TinyHumansClient`)
+that `src/sdk/src/client/` builds the typed Medulla surface on: auth, durable
+sessions, SSE event streaming, one-shot orchestration, and the public feedback
+board. It owns credential headers, the `{success, data}` envelope, and path
+percent-encoding.
 
-The `mock` feature is a normal dependency feature, not a dev-only one: the
-authoring surface dry-runs graphs against the engine's deterministic capability
-stand-ins in ordinary builds, not just in tests.
-
-### One `tinyagents`, and the patch entry is mandatory
-
-The graph must resolve exactly one `tinyagents`, and it must come from the
-vendored tree. OpenHuman's `vendor/tinycortex` requires `tinyagents = "2.1"`, so
-sourcing `tinycortex` from there collapses the graph to a single `tinyagents`,
-and the root `[patch.crates-io]` entry for `tinyagents` is **mandatory**.
-Omitting it does not fail loudly: `tinyagents 2.1.0` is published on crates.io,
-so the build silently resolves the registry copy instead of the vendored tree
-(~14 commits ahead).
-
-Verify with `cargo tree -i tinyagents`: the source must read `path+file://…`,
-never `registry+…`. `cargo tree -d` must report no duplicate `tiny*`.
-
-## Vendored OpenHuman core
-
-`vendor/openhuman` carries the OpenHuman core that medulla embeds. Several rules
-about it are load-bearing and easy to get wrong.
-
-Initialize it with `scripts/init-submodules.sh`, never with `--recursive`.
-`vendor/openhuman` has submodules of its own, two of which belong to the
-OpenHuman *desktop* app, including a Tauri fork that bundles CEF. `--recursive`
-clones both, and nothing in medulla's graph references either (the Cargo
-workspace excludes `vendor/`, so `app/src-tauri` is not a member). A git
-dependency would not help: Cargo updates git-dependency submodules recursively
-with no opt-out, which makes the CEF clone mandatory. The submodule plus an
-explicit init list is the only way to avoid it.
-
-The root `[patch.crates-io]` table is load-bearing. `[patch.crates-io]`
-applies only from the workspace root, so once OpenHuman is a path dependency
-*its* patch table is ignored, as is
-`vendor/openhuman/vendor/tinycortex/.cargo/config.toml`, which is CWD-scoped.
-This workspace's root manifest must therefore reproduce OpenHuman's entire table
-with paths rewritten to `vendor/openhuman/vendor/*`. Drop an entry and Cargo
-quietly resolves the published crate instead of the vendored tree.
+## One declaration style per crate
 
 Declare each vendored crate exactly one way: either as a direct path dependency
-or as a registry coordinate redirected by the patch table, and never both for the
-same crate. Mixing the two styles yields two `PackageId`s for one crate and an
-`E0308` where the types look identical, the first time a value crosses the
-medulla↔OpenHuman seam. Guard with `cargo tree -d`, which must report no
-duplicate `tiny*`.
+or as a registry coordinate redirected by the patch table, never both. Mixing the
+two yields two `PackageId`s for one crate and an `E0308` where the types look
+identical, the first time a value crosses the seam. `tinyhumans-sdk` is a path
+dependency because it has no registry coordinate to patch.
 
-When the two repos disagree on a shared pin, the newer pin wins and the bump
-lands in OpenHuman. Adopting an older OpenHuman pin wholesale is a hard compile
-break (for example, a `tinyplace` ancestor missing `signal::maintain`, which
-`src/sdk/src/daemon/transport/mod.rs` calls), so advance the pin *in OpenHuman*
-and let this gitlink follow rather than patching around it here.
+`[patch.crates-io]` applies only from the workspace root:
 
-OpenHuman must never depend on the `medulla` crate. Its default-ON
-`medulla-local` feature currently has an empty dependency list. The day someone
-gives it a real edge, `medulla-public → openhuman → medulla` becomes a Cargo
-dependency cycle and a hard failure.
+```toml
+[patch.crates-io]
+tinyagents = { path = "vendor/tinyagents" }
+tinyflows  = { path = "vendor/tinyflows" }
+```
 
-Coverage excludes the vendored tree. `vendor/` path deps are *local*
-packages under the workspace root, so `cargo-llvm-cov`'s default registry filter
-does not drop them; the gate's `--ignore-filename-regex` starts with
-`(^|/)vendor/` for that reason. Removing it sinks the 95% gate to roughly the
-first-party share of a very large tree.
+Dropping an entry does not fail loudly. Both crates are published, so Cargo
+silently resolves the registry copy instead of the vendored tree.
 
-### Updating the pin
+Verify with `cargo tree -i tinyagents` — the source must read `path+file://…`,
+never `registry+…` — and `cargo tree -d`, which must report no duplicate `tiny*`.
+
+## Updating a pin
 
 ```sh
 cd vendor/tinyflows
@@ -115,7 +82,27 @@ cargo build            # confirm the adapter seam still compiles
 cargo test
 ```
 
-Then update the pinned commit recorded above and commit the gitlink. Because
-`tinyflows` is pre-1.0 and still changing its `engine` entry points, expect the
-adapter seam in `src/sdk/src/tinyflows/` to need attention on an update; the rest
-of the SDK should not.
+Then commit the gitlink. Because `tinyflows` is pre-1.0 and still changing its
+`engine` entry points, expect `src/sdk/src/flow_engine/` to need attention on an
+update; the rest of the SDK should not.
+
+## Coverage
+
+Coverage excludes the vendored tree. `vendor/` path dependencies are local
+packages under the workspace root, so `cargo-llvm-cov`'s default registry filter
+does not drop them; the gate's `--ignore-filename-regex` starts with
+`(^|/)vendor/` for that reason.
+
+## History
+
+Until v0.11.0 the runtime was an embedded OpenHuman core vendored at
+`vendor/openhuman`. It carried sixteen submodules of its own — two belonging to
+the OpenHuman desktop app, including a Tauri fork bundling CEF — and because
+`[patch.crates-io]` applies only from the workspace root, this manifest had to
+reproduce that core's entire patch table rebased onto `vendor/openhuman/vendor/*`:
+ten entries, eight of them pinning a crate nothing here linked directly, each one
+silently resolving to a published crate if dropped. `scripts/init-submodules.sh`
+had to enumerate the same set by hand because Cargo reported one missing entry
+per resolution failure, costing a CI round trip each. Removing the core removed
+that whole class of failure; what is left is the three self-contained crates
+above.

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -36,7 +36,7 @@ the embedded core. The `sqlite` feature brings `tinyagents::session`, the durabl
 store behind `src/sdk/src/agent/history/`; `tools` brings the builtin tool family
 the loop dispatches. Neither is on by default in the crate.
 
-`tinyflows` is the DAG workflow engine behind the SDK's `flows` feature, reached
+`tinyflows` is the DAG workflow engine behind the SDK's `workflows` feature, reached
 through the adapter seam in `src/sdk/src/flow_engine/`. Its `mock` feature is a
 normal dependency feature rather than a dev-only one: the authoring surface
 dry-runs graphs against the engine's deterministic capability stand-ins in

--- a/docs/workspace-profiles.md
+++ b/docs/workspace-profiles.md
@@ -86,13 +86,20 @@ Drafts a profile for `dir` (default: the current directory) and writes
 `MEDULLA.md` there:
 
 1. Reads the directory's `AGENTS.md`, `CLAUDE.md`, and `README.md` (whichever
-   exist).
+   exist) — recorded as `sources`, but not otherwise used.
 2. Scans the file layout.
-3. Asks the configured model to distil them into a summary plus routing hints.
-4. Writes the result for you to review and edit.
+3. Writes a deterministic stub body alongside the scanned layout, for you to
+   review and edit.
 
-The draft is a starting point. The summary is what the orchestrator actually
-reads, so it is worth a pass by hand.
+The model-drafted body went out with the memory layer that owned the provider
+seam, so this stub is the only behaviour `init` has: `--offline` is accepted
+but is now a no-op, since there is no model call left to skip. `--config
+<path>` is likewise accepted but unused — `init` neither reads backend
+settings nor writes the registry.
+
+The layout is the part of the profile that carries real information, since it
+is read straight off the tree rather than drafted. The summary is a starting
+point for you to fill in by hand.
 
 `init` authors the file and stops there; it does **not** register the workspace.
 Use `medulla workspace add` for both.
@@ -107,15 +114,8 @@ template outside the crate root fails that build.
 | Flag | Effect |
 | --- | --- |
 | `--force`, `-f` | Overwrite an existing `MEDULLA.md`. Without it, `init` refuses rather than discarding an authored profile. |
-| `--offline` | Skip the model call and write the editable stub. |
-| `--config <path>` | Explicit config file for the backend/model settings. |
-
-### Model resolution
-
-Resolution takes one order: an explicit `OPENROUTER_API_KEY` wins, otherwise the
-backend's inference surface is used with the JWT from `medulla login`. With
-neither, or if the model call fails, `init` writes the stub and says so, so it
-always leaves you a usable file.
+| `--offline` | Accepted for backward compatibility; a no-op, since `init` never calls a model. |
+| `--config <path>` | Accepted but currently unused by `init`. |
 
 ## How a profile reaches the orchestrator
 

--- a/gitbooks/README.md
+++ b/gitbooks/README.md
@@ -36,6 +36,16 @@ Medulla commands fleets of agent harnesses. Instead of driving [Claude Code](htt
 
 That differs from pointing a harness at other harnesses in two ways that matter. Every running harness streams its input back as it happens, so what the orchestrator knows about the fleet is current rather than assembled after the fact. And the orchestrator's own reasoning surface stays small, because the bulk of the fleet's output is distilled before it arrives instead of being read into one context window.
 
+## No tmux, no wrapper
+
+Running many agents at once has, until now, meant one of two workarounds. Split the terminal and manage the panes yourself, or wrap the harnesses in another agent and hope it can read everything they produce. Medulla replaces both.
+
+It is one process in one terminal. Opening another agent is `Ctrl-T`: pick a harness or a shell, pick a directory, and it is running. There is no ceiling on how many you keep open — each gets its own PTY and its own live terminal state, maintained in the background whether or not it is the one on screen. A rail lists every one of them; the pane beside it shows whichever you have selected, switching instantly because that session's screen was never stale.
+
+And you are not the one polling. Medulla reads every backgrounded session for the signals that mean it needs a human — a permission prompt, a startup dialog, a blocking error, a bell, a dead session, a finished turn awaiting review — and surfaces them as one mark per row and a count in the title: `⚠ 3 waiting on you`. `Ctrl-]` attaches your keyboard to a session and detaches it again; the rest keep running.
+
+A multiplexer gives you N panes and no opinion about them. Medulla gives you the one that needs you.
+
 ## Correctness first, by design
 
 Medulla is built around one principle: get the right answer. When a worker fails, it re-delegates. When results look thin, it verifies. When a task splits, it fans out rather than guessing. Every task settles into a definite state and every budget is enforced, so an operation too large to eyeball still finishes with an answer you can act on.

--- a/gitbooks/developers/README.md
+++ b/gitbooks/developers/README.md
@@ -8,7 +8,7 @@ description: >-
 
 This is the developer home for Medulla: how to install and run the terminal app, how to embed the SDK in your own Rust code, how it is put together, and how to build the repository from source.
 
-The [product overview](../) is the high-level story; these pages are the hands-on detail. Everything here tracks the [`tinyhumansai/medulla-src`](https://github.com/tinyhumansai/medulla-src) repository, a two-crate Cargo workspace: the [`medulla`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) SDK library and the [`medulla-tui`](https://github.com/tinyhumansai/medulla-src/tree/main/src/tui/) app crate, which ships the `medulla` binary.
+The [product overview](../) is the high-level story; these pages are the hands-on detail. Everything here tracks the [`tinyhumansai/medulla-src`](https://github.com/tinyhumansai/medulla-src) repository, a three-crate Cargo workspace: the [`medulla`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) SDK library and the [`medulla-tui`](https://github.com/tinyhumansai/medulla-src/tree/main/src/tui/) app crate, which ships the `medulla` binary.
 
 ## Read next
 

--- a/gitbooks/developers/README.md
+++ b/gitbooks/developers/README.md
@@ -28,7 +28,7 @@ The [product overview](../) is the high-level story; these pages are the hands-o
 | [Attribution and Routing](attribution-and-routing.md) | The loopback proxy that rewrites OpenRouter attribution and keeps the provider key out of the harness. |
 | [Host Link Protocol](host-link-protocol.md) | The normative `medulla-link/1` wire specification, its forwarder rules, and its conformance tests. |
 | [Testing](testing.md) | Where tests live, the shared stand-ins, the offline and live suites, and the coverage gate. |
-| [Vendoring](vendoring.md) | The OpenHuman submodule, the patch table, and the rules a source build depends on. |
+| [Vendoring](vendoring.md) | The three vendored crates, the patch table, and the rules a source build depends on. |
 | [Contributing](contributing.md) | Build, test, lint, coverage, and the release process. |
 
 ## Install and run

--- a/gitbooks/developers/architecture.md
+++ b/gitbooks/developers/architecture.md
@@ -6,7 +6,7 @@ See [Why an Orchestrator](../why-an-orchestrator-model.md) for the product argum
 
 The public repository is a two-crate [Cargo](https://doc.rust-lang.org/cargo/) workspace with a strict separation between logic and rendering:
 
-* [`src/sdk/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) is the `medulla` SDK crate, a UI-free logic library. It holds the backend HTTP/SSE client, the runtime adapters over the embedded core, sessions, workflows, and the host-link integration. It is reusable from any Rust program.
+* [`src/sdk/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) is the `medulla` SDK crate, a UI-free logic library. It holds the backend HTTP/SSE client, the runtime adapters over it, the in-process agent loop, sessions, workflows, and the host-link integration. It is reusable from any Rust program.
 * [`src/tui/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/tui/) is the `medulla-tui` crate, shipping the `medulla` binary: a [ratatui](https://ratatui.rs/) terminal UI over the SDK. It owns state, rendering, input, and theming, and re-exports the SDK's UI-facing data modules.
 
 Reusable APIs live in the SDK; rendering and process wiring live in the app crate. The SDK depends only on its own traits and types, never on the TUI.
@@ -15,8 +15,12 @@ Reusable APIs live in the SDK; rendering and process wiring live in the app crat
 
 The UI drives everything through one trait, `Runtime`, plus its snapshot contract. The UI depends only on that trait, not on any concrete implementation, which is what makes the runtimes interchangeable and the whole thing testable offline. Two implementations ship:
 
-* `openhuman`, the embedded OpenHuman core, which is what the product runs on. It boots inside the `medulla` process, so there is no socket and no attach handshake.
-* `mock`, a scripted runtime for tests and demos, with no network, reached with `--mock`.
+* [`cloud`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/cloud/), which is what the product runs on. It drives the orchestration backend directly through the `client` module below: HTTP for mutations, a polled event cursor for the live feed.
+* [`mock`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/mock/), a scripted runtime for tests and demos, with no network, reached with `--mock`.
+
+`cloud` reclaims a name it already had. Before v0.11.0 an OpenHuman core was embedded in front of the transport, so every backend call became an RPC hop onto that core's own client — against the same deployment, with a second wire-type set and an error-string decode in the middle. Sessions were never local state; they live on the backend, so nothing was gained by asking an in-process core to fetch them. Dropping the core removed the hop, not the transport.
+
+Inside `cloud` the split is deliberate: `fold.rs` is pure translation from backend wire types to a render snapshot, `cell.rs` holds that snapshot plus a broadcast channel and the echo/pending-turn bookkeeping, and `mod.rs` is the thin part that needs a client — minting a session lazily on first submit, refreshing the roster, and polling events from a sequence cursor (backing off between an active 120 ms and an idle 1 s). [`connect/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/cloud/connect/) builds the client and reports readiness as `Ready`, `SignedOut`, or `Unusable`; two of the three answers are decisions this host can make without a round trip, and it now makes them locally instead of asking a booted core and classifying the error it returned.
 
 Alongside them sit the pieces both share:
 
@@ -36,7 +40,24 @@ The [`client`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src
 * SSE event streaming: the live event feed the UI folds into agent lanes and traces.
 * One-shot orchestration (`/orchestration/v1`): fire-and-collect delegation.
 
+* The public feedback board (`/feedback`).
+
 Every response is wrapped in a `{ "success": true, "data": ... }` envelope; errors arrive as `{ "success": false, "error": ..., "errorCode": ... }` and are surfaced as a typed `ClientError::Api` that preserves the `errorCode`.
+
+`client` is a typed Medulla surface over the shared `tinyhumans-sdk` transport rather than a second HTTP client of its own. The transport owns credential headers, the envelope, and path percent-encoding; the typed routes, the not-exposed-route gate, and the error taxonomy live here. See [Vendoring](vendoring.md).
+
+## The `openhuman` provider runs in-process
+
+`openhuman` is a harness provider name you can still type — in a task frame, in `baseHarness`, in the TUI's harness picker — and it is the one provider with no binary to spawn. Every other provider shells out to a coding-agent CLI and reads its JSONL; this one runs the agent loop inside the `medulla` process.
+
+The name is now the only thing OpenHuman about it. What runs is [`agent/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/agent/): a bounded model-and-tool loop on the vendored `tinyagents` harness, with Medulla's own tools (`fs`, `shell`, and the guard around them) and per-thread transcript history in `agent/history/`. The daemon side is [`daemon/providers/local/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/daemon/providers/local/), which builds the route and workspace, runs one turn, folds the harness event stream into Medulla's event vocabulary, and keeps a watchdog on a turn that is genuinely working.
+
+Two consequences are worth stating plainly, because both used to be the other way round:
+
+* **A turn carries no operator state.** It gets the checkout and the route, nothing else. There is no memory engine, no channel providers, no cron scheduler, and no access to an operator's credentials, because there is no core left to hold them. Dispatching a task no longer pulls a whole desktop product into the binary.
+* **There is no approval gate.** The embedded core refused external-effect tools from an unlabelled caller and parked them for a human to approve. The local harness runs what the model asks for, inside the workspace and the environment scrubbing described in [Environment Variables](environment-variables.md#what-an-agent-turn-cannot-see).
+
+Hooks, managed skills and MCP tools are deliberately absent here: those are installed onto a *child's* command line, and there is no child. The provider is also never auto-selected — detection only ever offers real CLIs, so a node reaches it by naming `openhuman` explicitly.
 
 ## Distillation is server-side
 
@@ -67,6 +88,12 @@ The rest splits by responsibility:
 [`workflows`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/) owns authored, durable, multi-step work, both definitions and their runs, and [`flow_engine`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/flow_engine/) is the adapter seam onto the vendored `tinyflows` engine. Engine coupling stays in the seam.
 
 What makes Medulla's use of that engine different from any other host embedding it is that an `agent` node is a *dispatched task*, not a model call. [`run/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/run/) executes and resumes, [`store/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/store/) is where workflows and run records live, [`authoring.rs`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/authoring.rs) edits a graph as a series of checked patches, [`ops/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/ops/) exposes the whole thing as one JSON-in/JSON-out surface, and [`mcp/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/mcp/) serves those same operations to a harness over MCP. The whole module sits behind the default `workflows` feature, so a slim build can drop the engine and its jq expression stack.
+
+## The workflow plane
+
+[`hub/plane/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/hub/plane/) is the workflow plane's contract with the orchestration backend, kept apart from the plumbing so the contract can be read on its own. `payloads.rs` is the Socket.IO wire shape — `RegisterWorkflows`, `WorkflowRequest`/`WorkflowResult` correlated by `request_id`, `WorkflowOp`, `CopilotOutcome`, and the `medulla:*` event names. `bridge.rs` is `WorkflowBridge`, the store-side trait an embedding host implements: reads are synchronous and dispatched on a blocking thread, `copilot` is async because it is a full agent turn rather than a read, and every method returns `Result<_, String>` because the error lands directly on a model's prompt surface as a tool result. The transport itself is in `hub::workflows` and `hub/socket/workflow.rs`, whose invariant is that every request is answered.
+
+Both halves used to be re-exported from the embedded core. That was sound while two hosts shared one socket implementation; with the core gone there is one host left, and sourcing a Medulla-to-Medulla-backend contract from a desktop product would have been the tail wagging the dog. The move was a relocation rather than a redefinition — field names, `rename_all`, and event strings are unchanged.
 
 ## Host-link integration
 

--- a/gitbooks/developers/architecture.md
+++ b/gitbooks/developers/architecture.md
@@ -39,7 +39,6 @@ The [`client`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src
 * Durable sessions (`/medulla/v1`): persistent orchestration sessions.
 * SSE event streaming: the live event feed the UI folds into agent lanes and traces.
 * One-shot orchestration (`/orchestration/v1`): fire-and-collect delegation.
-
 * The public feedback board (`/feedback`).
 
 Every response is wrapped in a `{ "success": true, "data": ... }` envelope; errors arrive as `{ "success": false, "error": ..., "errorCode": ... }` and are surfaced as a typed `ClientError::Api` that preserves the `errorCode`.

--- a/gitbooks/developers/architecture.md
+++ b/gitbooks/developers/architecture.md
@@ -2,9 +2,11 @@
 
 See [Why an Orchestrator](../why-an-orchestrator-model.md) for the product argument. This page is about the code: how the open-source SDK and TUI are put together, how they talk to the backend, and how the pieces named in the product story map onto modules you can read.
 
-## Two crates
+## Three crates
 
-The public repository is a two-crate [Cargo](https://doc.rust-lang.org/cargo/) workspace with a strict separation between logic and rendering:
+The public repository is a three-crate [Cargo](https://doc.rust-lang.org/cargo/) workspace with a strict separation between logic and rendering:
+
+* [`src/link/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/link/) is the `medulla-link` crate, the host-link transport on its own — no dependency on the SDK, so the wire can be read and tested without the rest.
 
 * [`src/sdk/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) is the `medulla` SDK crate, a UI-free logic library. It holds the backend HTTP/SSE client, the runtime adapters over it, the in-process agent loop, sessions, workflows, and the host-link integration. It is reusable from any Rust program.
 * [`src/tui/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/tui/) is the `medulla-tui` crate, shipping the `medulla` binary: a [ratatui](https://ratatui.rs/) terminal UI over the SDK. It owns state, rendering, input, and theming, and re-exports the SDK's UI-facing data modules.

--- a/gitbooks/developers/authentication.md
+++ b/gitbooks/developers/authentication.md
@@ -89,7 +89,7 @@ Either way, `login` then:
    marker.
 5. Re-checks that the home it just wrote to is the home this process resolves,
    and fails loudly with the reason if not.
-6. Sweeps up any legacy `credentials.json` left by an older install.
+6. Adopts any legacy `credentials.json` left by an older install.
 
 The base URL comes from `backend.baseUrl` in the [config](configuration.md); pass
 `--config <path>` to point at a different one.
@@ -135,8 +135,8 @@ anything that would make it a lie:
 
 ## `medulla logout`
 
-`logout` clears `session.json` (running it twice is not an error), removes legacy
-credential files under the account home, and then re-checks the precedence chain
+`logout` clears `session.json` (running it twice is not an error), removes the
+retired credential files described below, and then re-checks the precedence chain
 as described above.
 
 It deliberately leaves the account marker and the account's directory alone.
@@ -146,11 +146,22 @@ belongs to; signing back in returns you to the same home, config and logs. See
 
 ### Upgrading from a standalone credentials file
 
-Older installs kept a `credentials.json` alongside the runtime's own store, which
-gave two independent answers to "am I signed in?" — `medulla login` could report
-success while the runtime stayed signed out and the TUI kept opening its login
-screen. `login` and `logout` both delete any such file they find, since nothing
-reads it now and it holds a bearer token no logout could invalidate.
+Two credential files predate the current store: a `credentials.json` under the
+Medulla home, and an older one under the OS config directory. Both held a real
+JWT back when Medulla owned its own credential file. While sessions lived
+elsewhere, `login` and `logout` simply deleted them — a bearer token in a file no
+code path can invalidate is strictly worse than one in use.
+
+Now that the store is Medulla's again, deleting is the wrong move on login: the
+token in that file is the same app session the new store wants, so an install
+that predates the change is signed in and should stay signed in. `login`
+therefore **adopts** it — the JWT is verified through the same path as any other
+and, only once the new `session.json` is written, the old file is removed.
+
+`logout` still deletes them, and that is exactly why. Adoption is a startup
+behaviour; leaving a retired file behind at logout would mean the next launch
+verified the retired bearer and signed the operator straight back in, having just
+been told they were logged out.
 
 ## Token via environment
 

--- a/gitbooks/developers/authentication.md
+++ b/gitbooks/developers/authentication.md
@@ -1,7 +1,8 @@
 # Authentication
 
-Medulla authenticates to the backend with a JWT. You can supply it directly with
-an environment variable, or sign in and let the CLI store a verified credential.
+Medulla authenticates to the backend with a JWT. You can supply one directly
+through config or an environment variable, or sign in and let Medulla store a
+verified session itself.
 
 Two sign-in flows are available, chosen by where your browser is:
 
@@ -14,6 +15,46 @@ The browser flow cannot work over SSH. The backend redirects your browser to
 `http://127.0.0.1:<port>`, which is the loopback interface of the machine running
 the *browser*, not the remote host running Medulla, so the listener there never
 sees the callback. Use the code flow.
+
+## Where the credential comes from
+
+Three sources are consulted, in this order, and the first that yields a token
+wins:
+
+1. `backend.token` — a JWT written inline in the [config](configuration.md).
+2. `backend.tokenEnv` — the name of an environment variable to read, default
+   `MEDULLA_TOKEN`. An empty value is ignored rather than treated as a token.
+3. The stored session, `session.json` in the account's
+   [Medulla home](configuration.md#medulla-home).
+
+Every backend-facing surface resolves the token through that one chain — the
+TUI's readiness check, `medulla hub`, and `medulla login`/`logout` alike — so
+there is no path where one part of Medulla considers you signed in and another
+does not.
+
+The first two are *external credential sources*: the operator stated them
+explicitly, so they outrank anything Medulla stores for itself. That has two
+visible consequences, both deliberate:
+
+* `medulla login` refuses to save a session underneath one. It signs you in,
+  reports who you are, and then fails with `signed in, but <source> outranks the
+  stored session — this shell would keep using that credential, so the login was
+  not saved`. Storing a session that nothing would ever read is worse than
+  refusing.
+* `medulla logout` clears the store, then checks the chain again. If an external
+  source still yields a token it exits non-zero: `the stored session was cleared,
+  but this shell is still authenticated from <source> — remove it to finish
+  signing out`. Logout means no source authenticates you, not "one of three was
+  emptied".
+
+### The stored session is scoped to its issuer
+
+`session.json` records the `baseUrl` the token was issued by alongside the token
+itself, and the runtime hands the stored bearer only to a `backend.baseUrl` whose
+origin — scheme, host and port, normalized — matches it. Point a config at a
+different deployment and the stored session is simply not offered to it; sign in
+again against that deployment instead. `backend.token` and `backend.tokenEnv` are
+not filtered this way, because those are the operator's own explicit choice.
 
 ## `medulla login`
 
@@ -31,32 +72,85 @@ backend's OAuth page, and captures the JWT the backend redirects back with.
 
 With `--code` it binds nothing. It prints
 `<baseUrl>/auth/<provider>/login?redirect=cli` and waits on stdin. Open that URL
-anywhere, on another terminal's browser, your laptop, or your phone, sign in, and
-the page shows a one-time code. Paste it back and the CLI exchanges it for a JWT
-via `POST /auth/login-token/consume`. The code is single-use and expires after 15
+anywhere — another terminal's browser, your laptop, your phone — sign in, and the
+page shows a one-time code. Paste it back and the CLI exchanges it for a JWT via
+`POST /auth/login-token/consume`. The code is single-use and expires after 15
 minutes; the long-lived session is only ever issued to whoever redeems it, so
 what crosses your clipboard is not a bearer token.
 
-Either way `login` then verifies the token via `/auth/me`, prints who you are,
-and hands the JWT to the embedded OpenHuman core as its app session. The base URL
-comes from `backend.baseUrl` in the [config](configuration.md) (`--config <path>`
-to point at a different config).
+Either way, `login` then:
 
-The core is the only place a session lives. On the next `medulla` run the TUI
-finds the session and starts straight into the app. `medulla logout` ends the
-session and nothing else: the account stays selected, so signing back in returns
-to the same home and the same deployment. See
-[Medulla home](configuration.md#medulla-home). Precedence for the backend token
-is inline `backend.token`, then `backend.tokenEnv`, then the core's session.
+1. Verifies the token with `GET /auth/me` and prints who you are.
+2. Refuses to continue if an external credential source outranks the store.
+3. Adopts the account: sanitizes the account id the backend returned, and seeds
+   that account's `config.toml` with the `backend.baseUrl` it signed in against
+   (an existing, different value is reported rather than overwritten).
+4. Verifies once more, writes `session.json`, and only then publishes the account
+   marker.
+5. Re-checks that the home it just wrote to is the home this process resolves,
+   and fails loudly with the reason if not.
+6. Sweeps up any legacy `credentials.json` left by an older install.
+
+The base URL comes from `backend.baseUrl` in the [config](configuration.md); pass
+`--config <path>` to point at a different one.
+
+### What is stored, and where
+
+| Path | Contents |
+|---|---|
+| `<home>/session.json` | `{ "token", "userId", "baseUrl" }` — the session itself |
+| `<root>/active_user.toml` | `user_id = "..."` — which account directory this install reads |
+
+`<root>` is `~/.medulla` (or `MEDULLA_HOME`, or `./.medulla` under
+`MEDULLA_DEV`), and `<home>` is `<root>/<account id>` — `<root>/local` before
+you have ever signed in. There is no OS keychain involved: `session.json` is
+written to a temporary file created `0600`, fsynced, and renamed over the
+destination, so a reader never sees a half-written credential and the file is
+never world-readable even briefly.
+
+The account marker is written by the credential store, after the session file
+lands. Nothing can leave you with a marker pointing at an account whose session
+failed to write.
+
+### Account ids and `MEDULLA_USER`
+
+Every account's directory is named by the id the backend reports, so that id must
+be safe as a path segment: non-empty, not starting with `.`, and made only of
+`A-Z a-z 0-9 _ -`. It is checked before it is ever joined into a path. A backend
+response that names no account, or names an unusable one, is refused with an
+explicit error rather than guessed at — there is nowhere correct to store the
+session.
+
+`MEDULLA_USER` pins the active account for one process without touching the
+shared marker. Because it is a pin rather than a preference, Medulla refuses
+anything that would make it a lie:
+
+* Signing in as a different account than `MEDULLA_USER` names →
+  `MEDULLA_USER pins account <a>, but this token belongs to <b>`. Nothing is
+  stored.
+* The same conflict inside a running TUI → nothing is stored and the shared
+  account selection is left unchanged.
+
+`MEDULLA_USER=local` is the escape hatch back to the pre-login home.
+
+## `medulla logout`
+
+`logout` clears `session.json` (running it twice is not an error), removes legacy
+credential files under the account home, and then re-checks the precedence chain
+as described above.
+
+It deliberately leaves the account marker and the account's directory alone.
+Logging out is not forgetting which account and which deployment this install
+belongs to; signing back in returns you to the same home, config and logs. See
+[Medulla home](configuration.md#medulla-home).
 
 ### Upgrading from a standalone credentials file
 
-Older installs kept a `credentials.json` beside the core's store, which gave two
-independent answers to "am I signed in?": `medulla login` could report success
-while the core, whose session drives the runtime, stayed signed out and the TUI
-kept opening its login screen. `login` and `logout` delete any such file left
-behind, since nothing reads it now and it holds a bearer token no logout could
-invalidate.
+Older installs kept a `credentials.json` alongside the runtime's own store, which
+gave two independent answers to "am I signed in?" — `medulla login` could report
+success while the runtime stayed signed out and the TUI kept opening its login
+screen. `login` and `logout` both delete any such file they find, since nothing
+reads it now and it holds a bearer token no logout could invalidate.
 
 ## Token via environment
 
@@ -66,14 +160,18 @@ Skip login entirely and pass a JWT directly:
 MEDULLA_TOKEN=<jwt> medulla
 ```
 
+This is `backend.tokenEnv` at its default name. Remember it outranks the stored
+session for as long as it is exported: `medulla logout` will tell you so rather
+than silently leaving you authenticated.
+
 ## Logging in from the TUI
 
-When you start `medulla` and the embedded core has no app session, the TUI opens
-a login screen before the main app. There is no offline fallback: the mock
-runtime is reached only by asking for it with `--mock`.
+When you start `medulla` with no usable credential, the TUI opens a login screen
+before the main app. There is no offline fallback: the mock runtime is reached
+only by asking for it with `--mock`.
 
-Everything is one list, navigated with `↑↓` and `Enter`; nothing is bound to
-a bare letter, so no stray keystroke can start a flow. `Ctrl-C` quits from
+Everything is one list, navigated with `↑↓` and `Enter`; nothing is bound to a
+bare letter, so no stray keystroke can start a flow. `Ctrl-C` quits from
 anywhere.
 
 ```
@@ -86,26 +184,35 @@ anywhere.
   Quit
 ```
 
-Pick the method first, then the provider (google / github / twitter):
+Pick the method first, then the provider (google / github / twitter / discord):
 
-* Sign in with a browser opens your browser and waits for the callback on
+* **Sign in with a browser** opens your browser and waits for the callback on
   `127.0.0.1:<port>`. `Esc` goes back.
-* Sign in with a code shows the URL to open on any device and a field for
-  the code that page produces. `Ctrl-O` tries to open the URL here anyway (best
+* **Sign in with a code** shows the URL to open on any device and a field for the
+  code that page produces. `Ctrl-O` tries to open the URL here anyway (best
   effort, since the point of this flow is that there may be nothing to open),
   `Enter` submits, `Esc` goes back.
-* Paste an API key takes a JWT or key you already hold.
+* **Paste an API key** takes a JWT or key you already hold.
 
 A submitted value is classified by shape: 64 lowercase hex is redeemed via
 `/auth/login-token/consume`, anything else is treated as a ready-made JWT. A
 rejected value leaves you on the same screen, with the verification URL still up
 so you can fetch a fresh code.
 
-On a token from any path the TUI verifies it via `/auth/me`, flashes who you
-are, and hands it to the core, which validates it once more before storing it.
-The app then starts on the embedded core, with no restart. A core that cannot
-reach Medulla at all (no backend URL, or the surface compiled out) stops with
-that error instead of opening a login screen that could not fix it.
+On a token from any path the TUI verifies it via `/auth/me`, flashes who you are,
+stores it, and continues into the app with no restart.
+
+Signing in again from inside a running app is decided by which account the new
+token belongs to:
+
+* **The same account** — the session is stored and you carry on.
+* **A different account** — the marker moves and that account's config is seeded,
+  but no session is stored for it: `Signed in as a different account. Restart
+  medulla to finish signing in as them.` A running process has the previous
+  account's home, logs and workers open; adopting a new identity underneath that
+  is not something a restart-free path can honestly promise.
+* **Refused** — the backend named no account, named an unusable one, or
+  `MEDULLA_USER` pins this process elsewhere.
 
 ## Security model
 
@@ -114,8 +221,8 @@ that error instead of opening a login screen that could not fix it.
 The code is a one-time, 15-minute `type: login` session token bound to the
 account that just authenticated. It is not a JWT. It is redeemed exactly once
 (`/auth/login-token/consume` deletes it atomically), and the long-lived app
-session is issued to whoever redeems it. A code read off a shared screen or
-left in a clipboard therefore buys an attacker one race against you, within 15
+session is issued to whoever redeems it. A code read off a shared screen or left
+in a clipboard therefore buys an attacker one race against you, within 15
 minutes, rather than a standing credential, and a code that has already been
 pasted is inert.
 
@@ -127,14 +234,21 @@ apply and are not needed; no local socket is involved in this flow at all.
 The loopback listener hardens the callback against a hostile page sharing the
 same `127.0.0.1` origin:
 
-* A random 32-hex state nonce is appended to the `redirectUri` before it
-  reaches the backend, and the listener rejects any `/auth` callback whose `state`
-  is missing or mismatched (HTTP 400) while continuing to wait.
+* A random 32-hex state nonce is appended to the `redirectUri` before it reaches
+  the backend, and the listener rejects any `/auth` callback whose `state` is
+  missing or mismatched (HTTP 400) while continuing to wait.
 * It drops non-loopback peers, replies 405 to non-GET and 404 to non-`/auth`
   requests, and bounds each connection with a 5s read timeout and an 8 KiB
   buffer.
 
-The session is written by the core, into its own credential store (the OS
-keychain where one is available). Never commit tokens or `.env`; prefer
-`MEDULLA_TOKEN` and documented environment variables over inline credentials in
-committed config.
+### Credentials and agent turns
+
+An agent turn that runs a shell command never inherits Medulla's environment. The
+child is spawned from a cleared environment with a scrubbed set explicitly
+re-added: `MEDULLA_HOME` and `MEDULLA_USER` are always dropped, along with every
+variable whose name contains `TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `PASSWD`,
+`CREDENTIAL`, `AUTH` or `SESSION`. See
+[Environment Variables](environment-variables.md#what-an-agent-turn-cannot-see).
+
+Never commit tokens or `.env` files; prefer `MEDULLA_TOKEN` and the documented
+environment variables over inline credentials in committed config.

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -45,6 +45,27 @@ Feedback, and Settings. Workflows is present only in a build with the default
 `workflows` feature. See [The TUI](the-tui.md#the-tabs) for what each one holds and for the
 surfaces that are not in the tab bar of this build.
 
+### Slash commands
+
+Typed into the composer, `/` opens a peek of matching commands as you type; an
+exact match keeps showing its description until you press Enter.
+
+| Command | Description |
+| --- | --- |
+| `/new` | Open a new thread beside this one |
+| `/resume` | Pick up an earlier saved session |
+| `/session [harness] [path]` (alias `/harness`) | Start a local session |
+| `/abort` | Stop the running cycle |
+| `/clear` | Reset the view (history is kept) |
+| `/copy [all\|last]` | Copy the transcript to the clipboard |
+| `/usage` | Show account token usage |
+| `/settings` (alias `/theme`) | Open the appearance settings |
+| `/config` | Show the loaded configuration |
+| `/feedback` (alias `/fb`) | Open the feedback board |
+| `/mouse` | Toggle mouse capture (off to select text) |
+| `/help` | List the commands and keys |
+| `/quit` (aliases `/exit`, `/q`) | Exit medulla |
+
 ## `medulla run`
 
 A headless, scriptable path to a single instruction, and the one to drive from CI

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -171,7 +171,6 @@ one-line installer to paste into an SSH session on the machine you are adding.
 OSC 52 needs a terminal that accepts it: tmux wants `set -g set-clipboard on`,
 and some terminals disable it for security. The copy is also skipped when the
 daemon's output is piped. The address is printed on a line of its own either way.
-`--handle build-box` skips the copy entirely: type `@build-box` into Add Host.
 Pass `--no-pair` when the output is being parsed by a script.
 
 ## Harness wrappers

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -203,7 +203,7 @@ host configured before the rename keeps working:
 | `MEDULLA_HARNESS_RECEIVE_FROM` / `MEDULLA_<P>_RECEIVE_FROM` | Peer whose input control frames / plain DMs are injected (defaults to the owner). |
 | `MEDULLA_HARNESS_RECEIVE=0` / `MEDULLA_<P>_RECEIVE=0` | Disable inbound input injection. |
 | `MEDULLA_<P>_BIN` (`MEDULLA_CODEX_BIN`, `MEDULLA_CLAUDE_BIN`, `MEDULLA_OPENCODE_BIN`, `MEDULLA_OPENHUMAN_BIN`) | Override the provider binary. OpenHuman's bare `OPENHUMAN_BIN` predates the convention and is still read behind the namespaced pair. |
-| `MEDULLA_HARNESS_MODEL` / `MEDULLA_<P>_MODEL` | Override the model a turn runs on. Read today by the embedded OpenHuman harness (`MEDULLA_OPENHUMAN_MODEL`); see [Custom harness presets](configuration.md#custom-harness-presets) for the full precedence. |
+| `MEDULLA_HARNESS_MODEL` / `MEDULLA_<P>_MODEL` | Override the model a turn runs on. Read today by the in-process local harness (`MEDULLA_OPENHUMAN_MODEL`), which runs the turn on Medulla's own agent loop rather than a spawned CLI; see [Custom harness presets](configuration.md#custom-harness-presets) for the full precedence. |
 | `MEDULLA_<P>_SESSIONS_DIR` | Override the transcript directory the tailer watches. |
 
 If no owner is configured (and `--no-bridge` was not passed), the wrapper prints

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -301,7 +301,48 @@ executing it.
 
 `medulla workflow mcp` is not for a human to run. It is the command Medulla
 attaches to an ACP session so the harness on the other end can author workflows
-itself.
+itself. `medulla mcp` (no `workflow`) is the same server unrestricted to every
+tool family Medulla exposes, scoped by whatever grant the caller was handed.
+
+## `medulla skills`
+
+Put harness-native skills that trigger saved [workflows](../features/workflows.md)
+on disk, so an everyday Claude Code or Codex session run outside Medulla can
+still discover and start one:
+
+```sh
+medulla skills list                    # the managed skills currently on disk
+medulla skills install                 # write skills for every enabled workflow
+medulla skills sync                    # reconcile disk with the current workflow set
+medulla skills sync --prune            # additionally remove skills for workflows that are gone
+medulla skills uninstall <id...>       # remove skills for named workflows
+medulla skills uninstall --all         # remove every managed skill
+```
+
+With no verb it lists. `install`/`add` and `sync`/`refresh` take zero or more
+workflow ids (all enabled workflows when none are named); `uninstall`/`remove`/`rm`
+needs either explicit ids or `--all`.
+
+| Flag | Effect |
+| --- | --- |
+| `--harness <a,b>` | Restrict to `claude`, `codex`, `generic`, or `all` (repeatable and comma-joined; default: harnesses already set up). |
+| `--scope <user\|project\|managed>` | Install into `$HOME`, into this checkout, or into Medulla's own root that spawned harnesses are pointed at (default: `user`). |
+| `--dir <path>` | Explicit root, overriding `--scope`. |
+| `--with-mcp` | Also register `medulla mcp` with each harness. |
+| `--with-commands` | Also write the slash-command variant. |
+| `--tools <run\|full>` | Tool surface a skill-triggered session gets (default: `run`). |
+| `--prune` | Remove skills for workflows that no longer exist (`sync`, with no ids). |
+| `--all` | Remove every managed skill (`uninstall`, instead of naming ids). |
+| `--dry-run` | Report what would change and write nothing. |
+| `--json` | Emit JSON instead of the human summary. |
+
+Unlike the rest of the CLI, an unrecognised flag or a bad value here is a hard
+error rather than a silently ignored token: every flag decides where files get
+written, so a dropped `--dir` would retarget the whole operation at `$HOME`
+while still reporting success. `--prune` combined with explicit workflow ids is
+refused for the same reason — pruning decides what to remove by looking at
+every workflow, so restricting it to named ids would delete the skills for
+every workflow not named.
 
 ## `medulla init`
 

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -25,10 +25,10 @@ rejected as unknown subcommands.
 ## The TUI
 
 A [ratatui](https://ratatui.rs/) terminal UI over the SDK: chat with the
-orchestrator and watch agent lanes, traces, and context live. It runs on an
-OpenHuman core embedded in the same process, so there is no server to start and
-no socket to attach to. See [Runtimes](configuration.md#runtimes) for what happens
-when nobody is signed in, and
+orchestrator and watch agent lanes, traces, and context live. It drives the
+Medulla backend directly over the network — there is no embedded core process
+to boot and no socket to attach to. See [Runtimes](configuration.md#runtimes)
+for what happens when nobody is signed in, and
 [Upgrading from the external core socket](configuration.md#upgrading-from-the-external-core-socket)
 if you are coming from a version that used `--core-socket`.
 

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -13,6 +13,7 @@ the host link, and self-updating.
 | `medulla codex` / `claude` / `opencode` | [Harness wrappers](#harness-wrappers): run a CLI, bridged to your orchestrator. |
 | `medulla sessions` | List recent claude/codex sessions as JSON. |
 | `medulla workflow <cmd>` | [Workflows](#medulla-workflow): author, inspect, and run multi-step plans. |
+| `medulla skills <cmd>` | [Harness skills](#medulla-skills): put harness-native skills that trigger saved workflows on disk (`list` / `install` / `sync` / `uninstall`). |
 | `medulla init [dir]` | [Draft a MEDULLA.md](#medulla-init) workspace profile. |
 | `medulla workspace <cmd>` | [Workspace registry](#medulla-workspace): `add [dir]` / `list` / `remove <dir\|id>`. |
 | `medulla hub` | [Relay hosted-backend tasks](#medulla-hub) to configured host-link workers. |
@@ -20,7 +21,10 @@ the host link, and self-updating.
 | `medulla version` / `help` | Version string; usage. |
 
 Unknown first arguments are treated as arguments to the main TUI rather than
-rejected as unknown subcommands.
+rejected as unknown subcommands. Two further subcommands exist but are not for
+a human to type: `medulla mcp` serves Medulla's own tools over MCP on
+stdin/stdout, and `medulla hook <Event>` is the shim Medulla installs as every
+launched harness's own lifecycle hook. Medulla spawns both itself.
 
 ## The TUI
 

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -131,14 +131,11 @@ Daemon flags:
 | `--providers <a,b>` | Restrict the accepted harnesses (default: all found on `PATH`). |
 | `--default-provider <name>` | Choose the default harness among those available. |
 | `--workspace <dir>` | Set the primary task working directory (default: cwd). |
-| `--handle <name>` | Register an `@handle` on startup. |
 | `--name <label>` | Override the worker's advertised display name. |
 | `--model <name>` | Supply a default model hint passed to the harness. |
 | `--opencode-agent <name>` | Agent name for the OpenCode provider. |
-| `--skills <a,b>` | Extra skills to advertise. |
 | `--concurrency <n>` | Cap simultaneous executions. |
 | `--once` | Drain the current inbox once and exit (a probe). |
-| `--no-onboard` | Skip key publishing and directory registration. |
 | `--reonboard` | Replace the stored worker registration. |
 | `--no-pair` | Do not print the pairing block or copy the address. |
 | `--dangerously-skip-permissions` | Headless path: pass the provider's unsafe permission switch. |

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -33,7 +33,7 @@ orchestrator and watch agent lanes, traces, and context live. It drives the
 Medulla backend directly over the network — there is no embedded core process
 to boot and no socket to attach to. See [Runtimes](configuration.md#runtimes)
 for what happens when nobody is signed in, and
-[Upgrading from the external core socket](configuration.md#upgrading-from-the-external-core-socket)
+[The retired `--core-socket` flag](configuration.md#the-retired---core-socket-flag)
 if you are coming from a version that used `--core-socket`.
 
 TUI flags:

--- a/gitbooks/developers/cli-reference.md
+++ b/gitbooks/developers/cli-reference.md
@@ -69,8 +69,11 @@ exact match keeps showing its description until you press Enter.
 ## `medulla run`
 
 A headless, scriptable path to a single instruction, and the one to drive from CI
-or a container, since it needs no TTY. It boots the same embedded core the TUI
-uses, submits one instruction, and streams the folded cycle events to stdout as
+or a container, since it needs no TTY. It resolves the same layered config the
+TUI does, builds a client against the configured backend with the same token
+precedence every backend-facing surface shares (an inline `backend.token`, then
+`backend.tokenEnv`, then the stored `medulla login` session), submits one
+instruction, and streams the folded cycle events to stdout as
 newline-delimited JSON:
 
 ```sh
@@ -80,9 +83,15 @@ medulla run --config ./medulla.toml "..."
 
 Everything that is not a flag is joined into one instruction; with no instruction
 it errors. It emits each folded event as a JSON line and returns when the cycle
-ends. It binds the core's state directory, action directory, and endpoints from
-the resolved config before booting, so a scripted run pointed at `MEDULLA_HOME`
-reads and writes that home rather than the developer's real one.
+ends. Because the resolved config and the stored login session both come out of
+the operator's Medulla home, a scripted run pointed at `MEDULLA_HOME` reads and
+writes that home rather than the developer's real one. It fails immediately when
+there is nothing to sign in with (`not signed in — run medulla login, or set
+MEDULLA_TOKEN`).
+
+`--core-socket` used to point this at an external `medulla-serve` process; it is
+gone, and passing it is a hard error rather than being folded into the
+instruction text.
 
 | Flag | Effect |
 | --- | --- |

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -35,7 +35,7 @@ session minted on staging is never later verified against production.
 
 Under the home:
 
-* `workspace/` and `.openhuman/`: the embedded core's state and its config, including the app session `medulla login` stores.
+* `session.json`: the app session `medulla login` stores — the verified bearer, the account id, and the `baseUrl` that issued it. Owner-only (`0600`) on unix.
 * `config.toml`: the user-global config file.
 * `state/`: the default `stateDir`, holding chat history under `chats/`, and workflow run records and engine checkpoints under `state/workflows/runs/` and `state/workflows/checkpoints/`.
 * `workflows/*.json`: your [workflow](../features/workflows.md) definitions. A repository's own `<cwd>/.medulla/workflows/*.json` layers on top and shadows a personal one of the same id.

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -117,14 +117,17 @@ An inline `"token"` field is also accepted, but keep secrets out of committed fi
 
 ## Runtimes
 
-Two runtimes ship:
+Two runtimes ship, both implementing the same `Runtime` trait (see
+[Architecture › The Runtime trait](architecture.md#the-runtime-trait)):
 
-1. The embedded OpenHuman core, which is the product runtime. It boots inside the `medulla` process, so there is no server to start, no socket to resolve, no attach handshake to fail, and no unix-only restriction.
+1. `cloud`, the product runtime. It drives the orchestration API directly —
+   HTTP for mutations, a polled event cursor for the live feed — so there is no
+   server to start, no socket to resolve, and no attach handshake to fail.
 2. Mock, a scripted offline runtime for demos and tests, reached with `--mock`.
 
-`--mock` is checked first and skips the token lookup and the login screen entirely, which makes it the only way to get a working runtime with no backend at all. Otherwise the core boots and the TUI runs on it.
+`--mock` is checked first and skips the token lookup and the login screen entirely, which makes it the only way to get a working runtime with no backend at all. Otherwise `cloud` builds its client and the TUI runs on it.
 
-A core that boots but has no Medulla backend to talk to (no configured URL, or nobody signed in) takes the offline demo exactly as `--mock` does. This is the documented credential-free start, not a misconfiguration to surface; every drive method would otherwise fail behind a UI that looks live. Before that point the TUI opens the [login screen](authentication.md#logging-in-from-the-tui); press `m` to continue offline.
+A `cloud` runtime with no Medulla backend to talk to (no configured URL, or nobody signed in) takes the offline demo exactly as `--mock` does. This is the documented credential-free start, not a misconfiguration to surface; every drive method would otherwise fail behind a UI that looks live. Before that point the TUI opens the [login screen](authentication.md#logging-in-from-the-tui); press `m` to continue offline.
 
 ### Mock (zero setup)
 
@@ -138,18 +141,18 @@ A scripted demo: no credentials, no network, and the fastest way to explore the 
 
 ```sh
 medulla login          # browser OAuth; stores a verified session
-medulla                # runs on the embedded core
+medulla                # runs on the cloud runtime
 ```
 
 `MEDULLA_TOKEN=<jwt> medulla` supplies a bearer directly instead. See [Authentication](authentication.md).
 
-### Upgrading from the external core socket
+### The retired `--core-socket` flag
 
-Versions before the embedded core attached to an external `medulla-serve` NDJSON
-Unix socket via `--core-socket`, `MEDULLA_CORE_SOCKET`, or a `[core]` config
-section. The core now runs in-process. `medulla run` rejects `--core-socket` with
-that explanation instead of absorbing it into the instruction text, and a
-`[core]` section left in a config file is inert.
+Older versions attached to an external `medulla-serve` NDJSON Unix socket via
+`--core-socket`, `MEDULLA_CORE_SOCKET`, or a `[core]` config section. `medulla
+run` rejects `--core-socket` outright, naming it retired, rather than absorbing
+it into the instruction text, and a `[core]` section left in a config file is
+inert.
 
 ## Hosting on this device
 

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -80,6 +80,7 @@ has no config for them.
 | `fleet` | The declared `Host → Harness → Workspace → Agent` capacity chain and the agent-template catalog. |
 | `harness` | How harnesses the *operator* starts by hand behave: whether they launch with permissions bypassed (off by default, unlike a hosted task), and the manual launcher's recent/favorite workspace shortcuts. |
 | `attribution` | Whether commits made by a Medulla-launched harness carry the `Co-authored-by: Medulla` trailer. On by default. |
+| `hooks` | Operator-declared lifecycle hooks (`[[hooks]]`) for the harnesses Medulla launches, in the harness-native vocabulary (`PreToolUse`, `Stop`, …; camelCase spellings are also accepted). Empty by default. |
 | `hookDefaults` | Whether Medulla installs its own lifecycle reporting hooks into the harnesses it launches, alongside any operator-declared `[[hooks]]`. On by default. |
 | `router` | A custom OpenAI-compatible router the daemon spawns harnesses against. Absent leaves every harness unrouted. |
 | `customHarnesses` | Named presets that run a chosen model through Claude Code, Codex, OpenCode, or the in-process local (`openhuman`) harness. |

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -11,7 +11,7 @@ belongs to one account. There are two levels:
   * Default: `~/.medulla`.
   * Local dev: set `MEDULLA_DEV=1` (truthy is `1`/`true`, case-insensitive) and the root becomes `./.medulla` (relative to the cwd; gitignored).
   * Explicit: `MEDULLA_HOME=<path>` overrides both.
-* The **home** is `<root>/<account id>`, where config, state, logs, workflows, and the core's own workspace live.
+* The **home** is `<root>/<account id>`, where config, state, logs, and workflows live.
 
 The active account is recorded in `<root>/active_user.toml`, written by
 [`medulla login`](authentication.md). Before anyone signs in the account is

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -294,12 +294,15 @@ hostId = "this-device"
 apiKeyEnv = "OPENROUTER_API_KEY"
 ```
 
-The route is skipped in three cases: no key exported under `apiKeyEnv`, a
-`baseUrl` that resolves somewhere other than `openrouter.ai`, and a turn with no
-model resolved. Every one of those leaves the turn with no route to call, so it
-fails rather than running somewhere else — an `openhuman` preset with no key
-exported is not usable and, like every other base harness, is not advertised as
-capacity either.
+The route is skipped in three cases: the step names no router at all, no key is
+exported under `apiKeyEnv`, and a turn with no model resolved. Every one of
+those leaves the turn with no route to call, so it fails rather than running
+somewhere else — an `openhuman` preset with no key exported is not usable and,
+like every other base harness, is not advertised as capacity either. A
+non-OpenRouter `baseUrl` (a self-hosted gateway, a vendor's own OpenAI-compatible
+endpoint) is handed to the turn as spelled, with the key the preset named — only
+an OpenRouter endpoint is exchanged for a loopback mount and a machine-local
+token first.
 
 `apiKeyEnv` holds a variable name and never a value. The key stays in the process
 environment, and neither the config file nor the app's own state ever holds it. A

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -242,52 +242,47 @@ How the model reaches the CLI depends on the base harness. Claude Code takes it
 through the model-tier variables, with `model` on the Opus tier and `fastModel`
 on the Sonnet, Haiku, and small-fast tiers, so sub-agents stay on OpenRouter too.
 Codex and OpenCode take it through their own `-m` argument. OpenHuman takes it as
-the `model_override` on the core call — see below.
+the model id on the in-process turn's inference route — see below.
 
 ### Choosing the model an OpenHuman turn runs on
 
 A workflow step may name the harness id `openhuman`, and that turn runs in
-Medulla's own process on the embedded core rather than in a spawned CLI. Without
-a choice it runs on the core's `default_model`, the cloud alias a turn
-self-reports as `Chat V1 (Orchestrator)`. Three routes name a different one, and
-they resolve in this order, highest first:
+Medulla's own process, on the in-process local harness, rather than in a spawned
+CLI. Three routes name the model, and they resolve in this order, highest first:
 
 1. `MEDULLA_OPENHUMAN_MODEL` (deprecated spelling: `TINYPLACE_OPENHUMAN_MODEL`)
 2. `MEDULLA_HARNESS_MODEL` (deprecated spelling: `TINYPLACE_HARNESS_MODEL`)
 3. the step's own `config.model`, or the workflow's `defaults.model`
 4. the `[[customHarnesses]]` preset the step selected, through its `model`
 5. `medulla workflow run --model <name>`, then `[workflows] defaultModel`
-6. nothing — the core's own `default_model` answers
+
+Unlike a spawned CLI, which falls back to its own configured default when none
+of these name a model, the local harness has no default of its own: a turn with
+no model resolved fails outright rather than running on some ambient choice.
 
 The environment sits on top for the same reason `MEDULLA_<P>_BIN` does: it is the
 operator's override of what the configuration says, applied to the machine they
 are standing at, with no file to edit. An exported-but-blank value counts as
 unset.
 
-### Running an OpenHuman turn on OpenRouter
+### Running an OpenHuman turn on an inference route
 
-Naming a model is only half the answer: on its own the name is resolved against
-whatever providers the core already has, and one no configured provider serves is
-not an error — the agent loop falls through to its resolved default and records
-that it skipped the override.
+Naming a model is only half the answer, and for this harness it is the smaller
+half: unlike a spawned CLI, which can fall back to a coding tool's own
+configured provider, the local harness has no provider bindings of its own. It
+needs an explicit endpoint and credential for every call, and a turn that
+resolves a model but no route fails with "the local harness needs an inference
+route", not a quiet fallback.
 
-`baseUrl` and `apiKeyEnv` supply the other half, and they are live for
-`openhuman` presets. They reach the turn by a different road than they do for a
-spawned CLI, which has no child to hand an environment to: Medulla resolves the
-key named by `apiKeyEnv`, exchanges it at the loopback attribution proxy for a
-machine-local token, and passes the core the mount and that token as a
-**per-call** route. The core applies the route to that one turn's in-memory
-configuration and never writes it to disk, so pointing a workflow step at
-OpenRouter does not repoint the account's own OpenHuman inference — the next turn
-without a preset runs exactly where it did before.
+`baseUrl` and `apiKeyEnv` supply that route, and they reach the turn by a
+different road than they do for a spawned CLI, which has no child to hand an
+environment to: Medulla resolves the key named by `apiKeyEnv` and, for an
+OpenRouter endpoint, exchanges it at the loopback attribution proxy for a
+machine-local token, then passes the turn the mount and that token as a
+**per-call** route it uses for that turn alone.
 
-The route governs the four roles an agent turn runs on (chat, reasoning, agentic,
-coding). Background workloads — memory, embeddings, heartbeat, learning — stay
-where the account's configuration puts them, because they run tier-specific
-models a coding endpoint generally cannot serve.
-
-So a complete OpenHuman preset needs nothing installed and nothing pre-configured
-in the core:
+So a complete OpenHuman preset needs a model, an endpoint, and a key — nothing
+installed, but nothing implicit either:
 
 ```toml
 [[customHarnesses]]
@@ -299,19 +294,19 @@ hostId = "this-device"
 apiKeyEnv = "OPENROUTER_API_KEY"
 ```
 
-Routing is skipped, with no error, in three cases: no key exported under
-`apiKeyEnv`, a `baseUrl` that resolves somewhere other than `openrouter.ai`, and
-a turn with no model resolved. Each leaves the turn on the account's own
-OpenHuman configuration, which is why an `openhuman` preset that names only a
-model still works and is still advertised as capacity without an OpenRouter key —
-unlike every other base harness.
+The route is skipped in three cases: no key exported under `apiKeyEnv`, a
+`baseUrl` that resolves somewhere other than `openrouter.ai`, and a turn with no
+model resolved. Every one of those leaves the turn with no route to call, so it
+fails rather than running somewhere else — an `openhuman` preset with no key
+exported is not usable and, like every other base harness, is not advertised as
+capacity either.
 
 `apiKeyEnv` holds a variable name and never a value. The key stays in the process
 environment, and neither the config file nor the app's own state ever holds it. A
 host advertises a preset as capacity only when the named variable is set to
-something non-blank and the preset's base CLI is one that host runs. The key does
-not reach the harness either: an OpenRouter-bound run goes through a loopback
-proxy that hands the child a machine-local token instead. See
+something non-blank and the preset's base harness is one that host runs. The key
+does not reach the harness either: an OpenRouter-bound run goes through a
+loopback proxy that hands it a machine-local token instead. See
 [Attribution and routing](attribution-and-routing.md).
 
 Presets attach to a host by `hostId`, which must match the `address` of a

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -70,15 +70,22 @@ has no config for them.
 | --- | --- |
 | `backend` | The orchestration backend: base URL, token, and token env var name. |
 | `host` | Whether this device also runs the work it orchestrates, and the workspace and roots it advertises. |
+| `hosts` | Additional hosts on this same machine, each with its own working directory, device-local address, and agent registration. Additive: `host` keeps its meaning; a config with no `[[hosts]]` behaves exactly as before. |
 | `link` | Host-link identity, forwarder, and the peer roster for the daemon and the Overview panel. |
 | `hub` | The persisted worker roster and the selected default worker, so a fleet survives a restart. |
 | `stateDir` | Where local state is written. Default `<home>/state`; `MEDULLA_STATE_DIR` overrides. |
 | `opencode` | Worker display, model, agent, workspace, and concurrency for the OpenCode provider. |
-| `workflow` | The daemon's workspace allowlist, and the workspace roots whose `MEDULLA.md` rides every backend session mint. |
+| `workflow` | The daemon's workspace allowlist, and the workspace roots whose `MEDULLA.md` rides every backend session mint. Despite the name, unrelated to authored workflows — see `workflows` below. |
+| `workflows` | What authored workflows may do when they run: whether they may be listed and run at all, the default worker and harness/model hints a bare `agent` node dispatches to, and whether `code` nodes may execute (this host has no sandbox, so that grants a workflow author the daemon's own privileges). |
 | `fleet` | The declared `Host → Harness → Workspace → Agent` capacity chain and the agent-template catalog. |
+| `harness` | How harnesses the *operator* starts by hand behave: whether they launch with permissions bypassed (off by default, unlike a hosted task), and the manual launcher's recent/favorite workspace shortcuts. |
+| `attribution` | Whether commits made by a Medulla-launched harness carry the `Co-authored-by: Medulla` trailer. On by default. |
+| `hookDefaults` | Whether Medulla installs its own lifecycle reporting hooks into the harnesses it launches, alongside any operator-declared `[[hooks]]`. On by default. |
 | `router` | A custom OpenAI-compatible router the daemon spawns harnesses against. Absent leaves every harness unrouted. |
 | `customHarnesses` | Named presets that run a chosen model through Claude Code, Codex, OpenCode, or the in-process local (`openhuman`) harness. |
 | `budget` | Operator-declared per-provider budgets. Absent leaves every harness advertising an estimate. |
+| `routingStrategy` | The operator's persisted worker routing preference (`manual`, `balanced`, `cpuFirst`, `memoryFirst`) for choosing a host. Absent defaults to `manual` and is reconciled with the backend's own setting when present. |
+| `subscriptionRoutingStrategy` | How the orchestrator chooses among ready provider subscriptions after a host is selected (`manual`, `balanced`, `mostAvailableBudget`). Absent preserves the requested or host-default provider. |
 | `onboarding` | Welcome-flow completion state. |
 | `update` | `check = true`/`false` for the background release check. `MEDULLA_NO_UPDATE_CHECK` is the env kill-switch. |
 | `theme` | TUI colors: `primary`, `accent`, `selectionFg`, `dimBorder`, and `attention`, as [ratatui](https://ratatui.rs/) color names or `#rrggbb`. `attentionBlink` and `attentionBlinkSeconds` control whether and how quickly attention cues pulse. The Settings › Appearance subpage edits and persists these. |

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -77,7 +77,7 @@ has no config for them.
 | `workflow` | The daemon's workspace allowlist, and the workspace roots whose `MEDULLA.md` rides every backend session mint. |
 | `fleet` | The declared `Host → Harness → Workspace → Agent` capacity chain and the agent-template catalog. |
 | `router` | A custom OpenAI-compatible router the daemon spawns harnesses against. Absent leaves every harness unrouted. |
-| `customHarnesses` | Named presets that run a chosen model through Claude Code, Codex, OpenCode, or the embedded OpenHuman core. |
+| `customHarnesses` | Named presets that run a chosen model through Claude Code, Codex, OpenCode, or the in-process local (`openhuman`) harness. |
 | `budget` | Operator-declared per-provider budgets. Absent leaves every harness advertising an estimate. |
 | `onboarding` | Welcome-flow completion state. |
 | `update` | `check = true`/`false` for the background release check. `MEDULLA_NO_UPDATE_CHECK` is the env kill-switch. |

--- a/gitbooks/developers/contributing.md
+++ b/gitbooks/developers/contributing.md
@@ -20,10 +20,15 @@ formatting and runs Clippy with warnings denied.
 ## Build and run
 
 ```sh
-cargo run                       # debug build, starts the TUI (mock runtime)
+cargo run                       # debug build, starts the TUI
+cargo run -- --mock             # debug build, offline demo runtime (no backend, no login)
 cargo run --release             # optimized build
 cargo install --path src/tui    # installs the `medulla` binary onto your PATH
 ```
+
+`cargo run` with no flags drives `CloudRuntime` against the configured backend
+when a session is available; with nobody signed in, it falls back to the same
+offline mock runtime `--mock` selects explicitly.
 
 ## Validate
 

--- a/gitbooks/developers/environment-variables.md
+++ b/gitbooks/developers/environment-variables.md
@@ -159,7 +159,7 @@ readable.
 
 | Variable | Status |
 | --- | --- |
-| `MEDULLA_CORE_SOCKET` | Named the external `medulla-serve` NDJSON socket before the core was embedded. `medulla run` rejects the matching `--core-socket` flag with that explanation, and a `[core]` config section is inert. |
+| `MEDULLA_CORE_SOCKET` | Named the external `medulla-serve` NDJSON socket, back when the runtime was reached over one. There is no such socket now — the client drives the backend over HTTP. `medulla run` rejects the matching `--core-socket` flag, and a `[core]` config section is inert. |
 | `TINYPLACE_*` | The deprecated spelling of the harness knobs above. Still read, directly behind the `MEDULLA_*` name in each tier. |
 
 ## What an agent turn cannot see

--- a/gitbooks/developers/environment-variables.md
+++ b/gitbooks/developers/environment-variables.md
@@ -45,9 +45,9 @@ these can be set either way. Truthy values are `1` and `true`, case-insensitive.
 
 ## Harness selection and transport
 
-`<P>` is the uppercased provider: `CLAUDE`, `CODEX`, or `OPENCODE`. A
-per-provider key always beats the generic `MEDULLA_HARNESS_*` key, which beats
-the owner fallbacks and provider defaults. Within each tier the `MEDULLA_*` name
+`<P>` is the uppercased provider: `CLAUDE`, `CODEX`, `OPENCODE`, `OPENHUMAN`, or
+`SHELL`. A per-provider key always beats the generic `MEDULLA_HARNESS_*` key,
+which beats the owner fallbacks and provider defaults. Within each tier the `MEDULLA_*` name
 wins and the deprecated `TINYPLACE_*` spelling of the same name is read directly
 behind it, so hosts configured before the rename keep working.
 
@@ -55,7 +55,8 @@ behind it, so hosts configured before the rename keep working.
 | --- | --- | --- |
 | `MEDULLA_HARNESS_PROTOCOL` | `acp` makes the daemon talk to harnesses over the Agent Client Protocol instead of the legacy provider JSONL. | unset (legacy JSONL) |
 | `MEDULLA_HARNESS_TRANSPORT` | `app-server` selects the shared-process Codex path for a caller with no frame to state a flavor on. | unset |
-| `MEDULLA_<P>_BIN` | Overrides the provider binary. Claude also honours the legacy `TINYVERSE_CLAUDE_BIN`. Treated as untrusted configuration: an overridden binary is withheld the fleet grant. | `claude`, `codex`, `opencode` |
+| `MEDULLA_<P>_BIN` | Overrides the provider binary. Claude also honours the legacy `TINYVERSE_CLAUDE_BIN`, and `OPENHUMAN` the bare `OPENHUMAN_BIN` that predates the namespaced convention. Treated as untrusted configuration: an overridden binary is withheld the fleet grant. | `claude`, `codex`, `opencode` |
+| `MEDULLA_OPENHUMAN_BIN` | The standalone `openhuman-core` binary a bridged wrapper or PTY session spawns. It says nothing about the in-process `openhuman` provider, which spawns no binary at all — see [Architecture](architecture.md#the-openhuman-provider-runs-in-process). | unset |
 | `MEDULLA_SHELL_BIN` | The shell the Sessions picker offers first. Falls back to `$SHELL`, then `sh`. | `$SHELL` |
 | `MEDULLA_<P>_ARGS` | Extra arguments prepended to the child argv, whitespace-split. | none |
 | `MEDULLA_<P>_DM_TO`, `MEDULLA_HARNESS_DM_TO` | The owner a wrapped session forwards envelopes to, and by default receives input from. Falls back to `MEDULLA_OPENHUMAN_OWNER` and then `OPENHUMAN_OWNER_AGENT`. | unset |
@@ -114,6 +115,7 @@ operator. They are listed so a spawn's environment is readable.
 | `MEDULLA_WORKFLOW_TOOLS` | How much of the `workflow_*` tool surface a spawned MCP server serves: `full`, `propose` (read, reason, note, propose; never write or run a graph), or `run` (read a workflow and run it). An unrecognised value fails closed to `propose`. | `full` |
 | `MEDULLA_WORKFLOW_SCOPE` | Restricts evolution writes to the workflow being reviewed. | unset |
 | `MEDULLA_INPUT` | The path to the JSON input file a workflow `code` node's script is handed. Set by the engine; a workflow's own `env` declaration wins over it. | set per run |
+| `MEDULLA_WORKSPACE` | The checkout a workflow's steps operate in. Set by the engine on every node it runs, so a step reads the path from here rather than the graph declaring an input for it. | set per run |
 
 ## Attribution
 
@@ -159,6 +161,37 @@ readable.
 | --- | --- |
 | `MEDULLA_CORE_SOCKET` | Named the external `medulla-serve` NDJSON socket before the core was embedded. `medulla run` rejects the matching `--core-socket` flag with that explanation, and a `[core]` config section is inert. |
 | `TINYPLACE_*` | The deprecated spelling of the harness knobs above. Still read, directly behind the `MEDULLA_*` name in each tier. |
+
+## What an agent turn cannot see
+
+A `shell` command run by an agent turn does not inherit Medulla's environment.
+The child is spawned from a cleared environment and given an explicitly scrubbed
+set, so a credential the operator exported is not silently handed to a model's
+tool call.
+
+Dropped unconditionally:
+
+* `MEDULLA_HOME`, `MEDULLA_USER` — a turn that could reach the account home
+  could read the session file directly.
+
+Dropped by name, case-insensitively, wherever the substring appears:
+
+`TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `PASSWD`, `CREDENTIAL`, `AUTH`, `SESSION`.
+
+That is a denylist rather than an allowlist on purpose. An allowlist would have
+to enumerate every legitimate build variable — `PATH`, `HOME`, `LANG`,
+`CARGO_HOME`, the `npm_config_*` family, the Windows-only set — and a miss
+silently breaks somebody's build, which is a worse failure than a leaked
+variable name pattern being slightly too eager.
+
+It is deliberately too eager in one visible place: `SSH_AUTH_SOCK` contains
+`AUTH`, so a shelled command cannot reach the operator's ssh-agent, and a
+`git push` over SSH from inside a turn will not authenticate. Give the turn an
+HTTPS remote and a scoped token in the workspace if it needs to push.
+
+This is environment scoping, not a sandbox. What the process can reach on the
+filesystem or over the network is the operating system's to bound, not this
+tool's.
 
 ## Read next
 

--- a/gitbooks/developers/getting-started.md
+++ b/gitbooks/developers/getting-started.md
@@ -94,11 +94,11 @@ Add the SDK as a git dependency (the repo vendors its path deps, so no extra set
 medulla = { git = "https://github.com/tinyhumansai/medulla-src", tag = "v0.3.0" }
 ```
 
-The [`medulla` SDK crate](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) is a UI-free logic library: the HTTP/SSE client for the backend API, the runtime adapters over the embedded core, sessions, workflows, and the host-link integration. See [Architecture](architecture.md) for how the pieces fit together.
+The [`medulla` SDK crate](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/) is a UI-free logic library: the HTTP/SSE client for the backend API, the runtime adapters over it, the in-process agent loop, sessions, workflows, and the host-link integration. See [Architecture](architecture.md) for how the pieces fit together.
 
 ## Platform support
 
-Linux (x86\_64, aarch64), macOS (Apple Silicon), and Windows (x86\_64) all build and ship prebuilt binaries. The [daemon's](cli-reference.md#medulla-daemon) provider-spawn paths and the [harness wrappers](cli-reference.md#harness-wrappers) are unix-only. The interactive TUI, `medulla run`, and `medulla update` work everywhere, since the core is embedded rather than reached over a Unix socket.
+Linux (x86\_64, aarch64), macOS (Apple Silicon), and Windows (x86\_64) all build and ship prebuilt binaries. The [daemon's](cli-reference.md#medulla-daemon) provider-spawn paths and the [harness wrappers](cli-reference.md#harness-wrappers) are unix-only. The interactive TUI, `medulla run`, and `medulla update` work everywhere: they drive the backend over HTTP rather than attaching to a Unix socket.
 
 ### The Linux glibc floor
 

--- a/gitbooks/developers/glossary.md
+++ b/gitbooks/developers/glossary.md
@@ -273,6 +273,17 @@ account id, so everything else Medulla persists can be scoped to
 `<root>/<user id>`. It is written by the login flow and cleared by logout, the
 same layout the embedded OpenHuman core used for its own `~/.openhuman`.
 
+## tinyagents
+
+The vendored agent harness (`vendor/tinyagents`) that runs a [local provider](#local-provider)
+turn: the model/tool loop, the provider clients, and the `Tool` trait, but
+deliberately not a shell or a filesystem — what a tool is allowed to do depends
+on the host's threat model, so a crate that shipped one would be wrong for
+every host that disagreed. Medulla supplies those itself (`agent::tools`) and
+builds a configured `tinyagents::harness::runtime::AgentHarness` from a route
+and a checkout (`agent::harness`). Companion to `tinyflows` (see
+[Workflow](#workflow)), the same vendoring pattern for the workflow engine.
+
 ## Local provider
 
 The in-process daemon provider (`daemon::providers::local`): the one provider

--- a/gitbooks/developers/glossary.md
+++ b/gitbooks/developers/glossary.md
@@ -207,6 +207,114 @@ harness-agnostic wire protocol for coding agents. Medulla uses ACP v1 to talk to
 Claude Code, Codex, and OpenCode through one lifecycle and event stream, rather
 than teaching the orchestration layer each harness's private JSONL format.
 
+## Runtime
+
+The trait that abstracts what drives the TUI: submit an instruction, read back a
+render snapshot, and stream events. [`CloudRuntime`](#cloudruntime) is the
+runtime the product ships on; a scripted mock runtime backs `medulla --mock`
+and the test suites with no backend at all. `snapshot` and `subscribe` are the
+only two methods every surface actually depends on — a `RuntimeSnapshot` is a
+fold of an event stream, and that fold does not care where the events came
+from.
+
+## CloudRuntime
+
+The [runtime](#runtime) the product ships on. It drives the orchestration API
+directly over HTTP through `client::MedullaClient`, with a polled event cursor
+standing in for a live feed. Built with `CloudRuntime::new(client)` or
+`CloudRuntime::with_hub(client, hub)` when a host also relays a
+[hub](#hub) uplink, then configured further with `.with_backend(..)` and
+`.with_workspaces(..)`. It replaced a runtime that reached the backend by
+asking an embedded OpenHuman core to do it on this SDK's behalf — sessions
+were never local state, they live on the backend, so the core added a hop and
+nothing else.
+
+## `runtime::cloud::connect` and Readiness
+
+The module that decides whether a real launch gets a working `CloudRuntime`.
+`client_from_config` builds a `MedullaClient` from a loaded config and the
+process environment, resolving the bearer through the same
+`backend.token` → `backend.tokenEnv` → stored-session chain every
+backend-facing surface uses. `readiness` answers the question the client alone
+cannot: `Ready` (a backend is configured and a token was found), `SignedOut`
+(a backend is configured but nothing yields a token), or `Unusable` (no backend
+base URL is configured at all) — three states rather than two, because "run",
+"sign in", and "stop" each need a different response and collapsing any pair of
+them sends an operator down the wrong path.
+
+## Hub plane
+
+The workflow half of the [hub](#hub)'s contract with the Medulla orchestration
+backend: `hub::plane::payloads` is the Socket.IO wire shape (`WorkflowDescriptor`
+and friends) and `hub::plane::bridge::WorkflowBridge` is the trait an embedding
+host implements to answer it — listing its saved workflows, returning one's
+detail and run history, and running its authoring copilot. Both used to be
+re-exported from the embedded OpenHuman core; with the core gone, Medulla is
+the only host left that speaks them, so they are declared here directly instead
+of sourced from a desktop product.
+
+## App session and account marker
+
+The app session is Medulla's own record of a signed-in backend connection: a
+verified bearer token written to `<root>/<account id>/session.json` by
+`auth::session::store`, which checks a candidate token against `/auth/me`
+before persisting it so a bad paste fails at `medulla login` rather than on
+every later call. Reading it back is resolved through the same precedence as
+every other backend-facing call: an inline `backend.token`, then
+`backend.tokenEnv` (`MEDULLA_TOKEN` by default), then this stored session.
+There is no OS keychain involved. `medulla login` also *adopts* a legacy
+`credentials.json` left by an older store — verifying it and rewriting it as a
+session rather than discarding it — and only `medulla logout` deletes a stored
+session.
+
+The account marker, `active_user.toml` at the root of the Medulla home, is the
+one file a process can read before it knows who it is: it names the active
+account id, so everything else Medulla persists can be scoped to
+`<root>/<user id>`. It is written by the login flow and cleared by logout, the
+same layout the embedded OpenHuman core used for its own `~/.openhuman`.
+
+## Local provider
+
+The in-process daemon provider (`daemon::providers::local`): the one provider
+with no binary behind it. Every other provider is a CLI Medulla resolves,
+spawns, and folds JSONL from; this one runs a turn as a bounded model/tool loop
+directly in this process, on the vendored `tinyagents` harness plus Medulla's
+own tools (`agent::tools`: a path-owning filesystem tool, a supervised shell,
+and the containment guard both are rooted at). It replaced the RPC this used to
+make into an embedded OpenHuman core, which meant running a model in a loop
+with three tools pulled in a whole desktop product — memory engine, channel
+providers, cron scheduler — to get them.
+
+Selected by naming the `openhuman` [provider](#provider) — the id string is
+unchanged even though nothing is embedded any more. It is never
+auto-detected, so a task reaches it only by naming it explicitly. It has no
+access to an operator's OpenHuman memory, flows, or credentials (there is no
+core left to hold them), no hooks, managed skills, or MCP tools (all three
+install onto a *child's* command line, and there is no child here), and no
+approval gate — the embedded core used to park external-effect tools for
+approval from an unlabelled caller; this harness runs what the model asks for.
+
+## `HarnessProvider::Shell`
+
+A plain interactive shell — `bash`, `zsh`, whatever `$SHELL` names — not a
+coding agent. It exists so an operator can open a terminal beside their agents
+in the same pane, on the same host, with the same working directory. It is
+deliberately excluded from every path that treats providers as interchangeable:
+never detected as an available daemon provider, and the one
+[`HarnessProvider`](#provider) whose `is_dispatchable()` answers `false`, so a
+task frame naming `shell` is refused at the parse before it reaches a host. A
+shell reads no prompt and reports no completion, so a dispatched turn to one
+would never answer — and a peer able to name one would have a way to run
+arbitrary commands on the host with no harness in between.
+
+## Harness wrapper
+
+`Command::Wrapper(HarnessProvider)`, in the TUI's CLI: launching a coding-agent
+CLI as a transparent, host-link-bridged wrapper rather than the TUI itself.
+Reached by argv0 — running the binary as `claude`, `codex`, or `opencode`
+(typically a symlink to the `medulla` binary named after the provider) selects
+the matching wrapper instead of the ordinary subcommand parse.
+
 ## MEDULLA.md
 
 A workspace profile file at a repository root. It carries a short summary

--- a/gitbooks/developers/harness-integration.md
+++ b/gitbooks/developers/harness-integration.md
@@ -16,6 +16,30 @@ are independent of each other:
 * `codex-server`, a Codex flavor that runs tasks as threads on one long-lived
   `codex app-server` process instead of forking a CLI per task.
 
+## Providers
+
+Five [`HarnessProvider`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/protocol/frames/types.rs)
+values exist, and only three of them are CLIs the daemon can detect and
+auto-select: `claude`, `codex`, and `opencode` (`daemon::providers::DAEMON_PROVIDERS`).
+The other two are named explicitly or not reached at all.
+
+`openhuman` is the in-process provider (`daemon::providers::local`). It has no
+binary behind it — a task dispatched to it runs as a bounded model/tool loop
+directly in this process, on the vendored `tinyagents` harness plus Medulla's
+own filesystem, shell, and guard tools, rather than a spawned and JSONL-folded
+CLI. It is dispatchable, but never auto-selected: a task reaches it only by
+naming it. Because there is no child process, it has no hooks, no managed
+skills, and no MCP tools — all three install onto a child's command line — and
+no approval gate: the harness runs what the model asks for rather than parking
+an external-effect tool call for approval.
+
+`shell` is a plain interactive shell (`bash`, `zsh`, whatever `$SHELL` names),
+not a coding agent. It is never detected as an available provider and never
+dispatchable — `HarnessProvider::is_dispatchable` answers `false` for it alone
+— so a task frame naming `shell` is refused at the parse before it reaches a
+host. It exists only so an operator can open a terminal beside their agents in
+the TUI, in the same pane and working directory.
+
 ## The wire contract
 
 An agent harness is a long-lived agent that accepts natural-language

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -216,6 +216,7 @@ of truth. `lib.rs` defines the public surface.
 | [`flow_engine/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/flow_engine/) | The adapter seam between Medulla and the `tinyflows` workflow engine (`workflows` feature). |
 | [`harness_contract/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/harness_contract/) | The public agent-harness wire-contract types. See [Harness integration](harness-integration.md#the-wire-contract). |
 | [`harness_hooks/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/harness_hooks/) | The hooks Medulla installs into a launched harness, and the launch policy around them. |
+| [`harness_transcript/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/harness_transcript/) | What a harness actually said while it served one task, kept for replay. |
 | [`harness_work/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/harness_work/) | What a coding-agent harness is working on, in one vocabulary. |
 | [`history_upload/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/history_upload/) | Sharing local coding-agent history to earn onboarding credit. |
 | [`home/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/home/) | The Medulla home directory and the early `.env` loader. |

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -236,10 +236,11 @@ of truth. `lib.rs` defines the public surface.
 | [`workflows/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/workflows/) | Authored, durable, multi-step work: workflow definitions and their runs (`workflows` feature). |
 | [`wrapper/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/wrapper/) | The transparent harness wrapper behind `medulla codex`, `medulla claude`, and `medulla opencode`. |
 
-Three files sit at the top level beside them: `clock.rs` (wall-clock helpers),
-`persistence.rs` (shared atomic file persistence, crate-private), and
-`tokio_tuning.rs` (Tokio runtime tuning for any process that may host an agent
-turn).
+Four files sit at the top level beside them: `clock.rs` (wall-clock helpers),
+`harness_tools.rs` (whether a harness Medulla launches receives Medulla's own
+MCP tools), `persistence.rs` (shared atomic file persistence, crate-private),
+and `tokio_tuning.rs` (Tokio runtime tuning for any process that may host an
+agent turn).
 
 ## Read next
 

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -212,7 +212,6 @@ of truth. `lib.rs` defines the public surface.
 | [`codex_overrides/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/codex_overrides/) | Codex `-c` config overrides that make a routed Codex run reach a non-OpenAI model. |
 | [`config/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/config/) | The `medulla.tui.json`-compatible config the TUI reads, plus the `backend` section. Permissive: missing fields take defaults, unknown fields are ignored. |
 | [`control_socket/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/control_socket/) | The local control socket a spawned harness reaches, and the grant tokens that scope it. |
-| [`core_host/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/core_host/) | Booting the embedded OpenHuman core in this process. |
 | [`daemon/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/daemon/) | The headless `medulla daemon`: offering this machine's coding-agent CLIs as an addressable agent, over plain prompts and the `medulla-task/1` protocol. |
 | [`flow_engine/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/flow_engine/) | The adapter seam between Medulla and the `tinyflows` workflow engine (`workflows` feature). |
 | [`harness_contract/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/harness_contract/) | The public agent-harness wire-contract types. See [Harness integration](harness-integration.md#the-wire-contract). |

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -201,6 +201,7 @@ of truth. `lib.rs` defines the public surface.
 
 | Module | Responsibility |
 | --- | --- |
+| [`agent/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/agent/) | Medulla's own local agent: a `tinyagents` harness, a tool surface (`fs`, `shell`, and the guard around them), and one turn driver. What the `openhuman` harness id runs on. |
 | [`agents/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/agents/) | Where agent templates come from: the built-in coding catalog, the on-disk `.medulla/agents/*.toml` store that supersedes it, and the installer between them. |
 | [`attribution/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/attribution/) | Git commit attribution: the `Co-authored-by` trailer and the hook shims that carry it without disabling a repository's own hooks. |
 | [`auth/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/auth/) | An RFC 8252 loopback OAuth flow against the backend, plus the pure URL and query helpers the CLI and tests share. |

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -7,8 +7,8 @@ description: >-
 # The Rust SDK
 
 `medulla` is the library crate at [`src/sdk/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/): a UI-free logic
-library holding the backend HTTP and SSE client, the runtime adapters over the
-embedded OpenHuman core, the coding-agent daemon, sessions, workflows, the
+library holding the backend HTTP and SSE client, the runtime adapters over it,
+the in-process agent loop, the coding-agent daemon, sessions, workflows, the
 host-link integration, and the UI-facing data surface the terminal app renders.
 The `medulla-tui` crate consumes it; nothing in the SDK depends on the TUI.
 

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -37,8 +37,8 @@ The crate has one feature.
 `workflows::ops`. The `fleet_*` family beside it depends only on
 `control_socket`.
 
-The embedded OpenHuman core is not behind a feature. It is the runtime the SDK
-hosts, and a build without it would have nothing to offer but the offline mock.
+The `cloud` runtime is not behind a feature. It is the runtime the SDK hosts,
+and a build without it would have nothing to offer but the offline mock.
 
 ## The `Runtime` trait
 

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -100,8 +100,8 @@ Beside the trait sit three supporting modules:
 
 `runtime::headless::drive_once` attaches a runtime, submits exactly one
 instruction, streams the folded events to a writer as NDJSON, and returns once
-the cycle result lands. It is generic over `Runtime`, so it works against the
-embedded core in production and against the mock in tests.
+the cycle result lands. It is generic over `Runtime`, so it works against
+`cloud` in production and against the mock in tests.
 
 ```rust
 use std::sync::Arc;

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -64,19 +64,28 @@ Core methods:
 Two implementations ship, both under
 [`src/sdk/src/runtime/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/):
 
-* `runtime::openhuman::OpenHumanRuntime` is what the product runs on. It wraps
-  the OpenHuman core booted in this process (`OpenHumanRuntime::new(core)`, or
-  `with_hub(core, hub)` when the outbound dispatch hub is wired in), so there is
-  no socket and no attach handshake.
+* [`runtime::cloud::CloudRuntime`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/cloud/)
+  is what the product runs on. It drives the orchestration API directly through
+  a [`MedullaClient`](#the-backend-client) (`CloudRuntime::new(client)`, or
+  `with_hub(client, hub)` when the outbound dispatch hub is wired in): HTTP for
+  submit/abort/new-session, and a polled event cursor — backing off between an
+  active 120 ms and an idle 1 s — for the live feed. There is no socket and no
+  attach handshake.
+  [`runtime::cloud::connect`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/cloud/connect/)
+  builds that client from config and the environment and reports whether it is
+  usable as `Readiness::Ready`, `Readiness::SignedOut`, or
+  `Readiness::Unusable(reason)`.
 * `runtime::mock::MockRuntime` is a scripted offline runtime for tests and demos.
   `MockRuntime::demo()` gives a populated snapshot (a roster, presence, a couple
   of turns, a completed delegated task); `MockRuntime::empty()` gives a bare one.
   It also exposes scripting seams: `script_event`, `set_workers`, `set_running`,
   `recorded_calls`, `recorded_handoffs`.
 
-Earlier versions carried an HTTP and SSE cloud-backend runtime and a
-`medulla-serve` unix-socket runtime. Both were removed once the core was
-embedded; the module docs in `lib.rs` still name them.
+`cloud` reclaims a name it already had. Before v0.11.0 an OpenHuman core was
+embedded in front of the transport, so every backend call became an RPC hop
+onto that core's own client — against the same deployment, with a second wire-
+type set and an error-string decode in the middle. Dropping the core removed
+the hop, not the transport.
 
 Beside the trait sit three supporting modules:
 

--- a/gitbooks/developers/sdk.md
+++ b/gitbooks/developers/sdk.md
@@ -227,7 +227,7 @@ of truth. `lib.rs` defines the public surface.
 | [`mcp/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/mcp/) | Medulla's own MCP server, offered to the harnesses it spawns (`workflows` feature). |
 | [`onboarding/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/onboarding/) | First-run worker registration orchestration. |
 | [`protocol/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/protocol/) | Medulla's own wire protocol for the TUI and daemon, plus the centralized environment-variable resolution both share. |
-| [`runtime/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/) | The `Runtime` trait, its snapshot contract, and the `openhuman` and `mock` implementations. |
+| [`runtime/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/runtime/) | The `Runtime` trait, its snapshot contract, and the `cloud` and `mock` implementations. |
 | [`session_history/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/session_history/) | Recent-session history for local harness sessions. |
 | [`sessions/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/sessions/) | Interactive coding-agent session management: the two lifetime classes, the two turn-source drivers, and the machinery that runs them. |
 | [`ui/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/ui/) | The UI-facing data surface: `events`, `agents` lane folding, `stream` derivations, `chat_store`, the `work` panel, and `util`. Rendering lives in `medulla-tui`. |

--- a/gitbooks/developers/the-tui.md
+++ b/gitbooks/developers/the-tui.md
@@ -1,9 +1,10 @@
 # The TUI
 
 `medulla` with no arguments starts the terminal app: a [ratatui](https://ratatui.rs/)
-interface over an OpenHuman core embedded in the same process. There is no
-server to start and no socket to attach to. With nobody signed in it opens a
-login screen; `medulla --mock` skips straight to the offline demo runtime.
+interface driven by `CloudRuntime`, which talks straight to the Medulla
+backend over HTTP. There is no server to start and no socket to attach to. With
+nobody signed in it opens a login screen; `medulla --mock` skips straight to
+the offline demo runtime.
 
 ## The tabs
 

--- a/gitbooks/developers/the-tui.md
+++ b/gitbooks/developers/the-tui.md
@@ -16,7 +16,7 @@ the offline demo runtime.
 | Subconscious | A placeholder for the layer under the work: what it filters on intake, what it learns from the gap between expectation and outcome, and what it escalates for a human to approve. Nothing here is live yet. |
 | Changes | The session's Git changes: a rail of changed files, commits, patches, and review comments, with the selected unified patch beside it. `b` sets the baseline. |
 | Hosts | What capacity exists: Hosts, Harness Types, Hooks, Agent Templates, Add Host, Strategies. |
-| Feedback | The feedback board for the active runtime, with the selected item's body and comments. A runtime with no board (the local and core runtimes, or a signed-out session) shows a single hint panel instead. |
+| Feedback | The feedback board for the active runtime, with the selected item's body and comments. The mock demo runtime always has a scripted board; a signed-out or unconfigured backend connection has none, and shows a single hint panel instead. |
 | Settings | Usage, Appearance, Status line, Config, Feedback, Trace, Context, Account, Help, grouped under General, Debug, and About. |
 
 `Tab` walks the top-level views. Within a tab, `↑↓` walk the left nav and `1`-`9`

--- a/gitbooks/developers/the-tui.md
+++ b/gitbooks/developers/the-tui.md
@@ -181,6 +181,14 @@ Most of it is recognised from what the harness paints, in order of specificity:
 5. **The terminal bell** — the universal fallback, in case a prompt is worded
    differently or not recognised.
 
+A sixth signal does not come from the screen at all: Claude Code raises a
+`Notification` lifecycle hook when it stops on a tool-use approval, an MCP
+elicitation form, or a background agent waiting on you, and Medulla treats a
+`Notification` in that harness's hook log as a wait. The screen scraper still
+wins when it can name something more specific; the hook is the fallback that
+catches a stop the screen paints nothing recognisable for. Codex never reports
+it, so this cue is Claude's alone.
+
 Two states cannot be read off a screen at all, and are taken from the session
 itself. A harness that **died** leaves its terminal frozen on whatever it last
 painted, which is often an ordinary composer — the row now goes red and says

--- a/gitbooks/developers/troubleshooting.md
+++ b/gitbooks/developers/troubleshooting.md
@@ -79,26 +79,39 @@ peers, and bounds each connection with a 5 s read timeout and an 8 KiB buffer.
 
 ### The TUI opens a login screen even though `medulla login` said it worked
 
-The embedded core holds the only session. If the core cannot store or read it,
-the TUI has nothing to start on. Older installs kept a separate
-`credentials.json` beside the core's store, which could report success while the
-core stayed signed out; `login` and `logout` now delete any such file left
-behind.
+Something outranks the stored session, or the session was stored somewhere this
+process does not read. The credential chain is inline `backend.token`, then
+`backend.tokenEnv` (default `MEDULLA_TOKEN`), then `<home>/session.json` — and
+`medulla login` now refuses to store a session underneath one of the first two
+rather than saving one nothing would read, so a login that reports this is
+telling you which source to remove.
+
+A stored session is also scoped to the deployment that issued it: it records its
+own `baseUrl` and is only offered to a `backend.baseUrl` with a matching origin.
+If you have repointed the config at a different deployment, sign in again against
+that one.
+
+Older installs kept a separate `credentials.json` beside the runtime's store,
+which could report success while the runtime stayed signed out; `login` and
+`logout` now delete any such file left behind.
 
 Check which account you are on. The active account is recorded in
 `<root>/active_user.toml`, and `MEDULLA_USER=<id>` selects a different one for a
 single process ahead of that marker. `MEDULLA_USER=local` reaches the pre-login
 home. See [Medulla home](configuration.md#medulla-home).
 
-### A core with no backend stops instead of offering a login screen
+### No backend configured: it stops instead of offering a login screen
 
-A core that cannot reach Medulla at all (no backend URL configured, or the
-surface compiled out) reports that error rather than opening a login screen that
-could not fix it. Check `backend.baseUrl` in the config, or `MEDULLA_API_URL`,
-and whether `MEDULLA_STAGING` is pointing you somewhere you did not intend.
+Readiness is three states, not two, because a host answers each differently: run,
+sign in, or stop. Reachable but signed out opens the login flow. No backend URL
+at all reports that error instead, because a login screen cannot fix a missing
+base URL. Check `backend.baseUrl` in the config, or `MEDULLA_API_URL`, and
+whether `MEDULLA_STAGING` is pointing you somewhere you did not intend.
 
 To get a working interface with no backend at all, ask for the mock runtime:
-`medulla --mock`, or press `m` on the login screen.
+`medulla --mock`. The login screen deliberately does not offer it — a failed
+sign-in should not quietly land you in a scripted demo you might mistake for the
+product.
 
 ## Hosting and the daemon
 

--- a/gitbooks/developers/troubleshooting.md
+++ b/gitbooks/developers/troubleshooting.md
@@ -91,9 +91,10 @@ own `baseUrl` and is only offered to a `backend.baseUrl` with a matching origin.
 If you have repointed the config at a different deployment, sign in again against
 that one.
 
-Older installs kept a separate `credentials.json` beside the runtime's store,
-which could report success while the runtime stayed signed out; `login` and
-`logout` now delete any such file left behind.
+Older installs kept a separate `credentials.json`, which could report success
+while the runtime stayed signed out. `login` now adopts that file — verifying its
+JWT and rewriting it as a proper session — and only `logout` deletes it. See
+[Authentication](authentication.md#upgrading-from-a-standalone-credentials-file).
 
 Check which account you are on. The active account is recorded in
 `<root>/active_user.toml`, and `MEDULLA_USER=<id>` selects a different one for a

--- a/gitbooks/developers/vendoring.md
+++ b/gitbooks/developers/vendoring.md
@@ -1,169 +1,127 @@
 ---
 description: >-
-  How the vendored OpenHuman core and its crates are consumed, and the rules a
+  How the three vendored crates under vendor/ are consumed, and the rules a
   source build depends on.
 ---
 
 # Vendoring
 
-Some upstream crates are consumed from a git submodule under `vendor/` rather
+Three upstream crates are consumed from git submodules under `vendor/` rather
 than from crates.io. The workspace `exclude = ["vendor", "worktrees"]` keeps them
 out of `members`, so they carry their own lints and tests instead of joining this
 repository's CI gates.
 
+| Submodule | Upstream | What it is |
+| --- | --- | --- |
+| `vendor/tinyagents` | [`tinyhumansai/tinyagents`](https://github.com/tinyhumansai/tinyagents) | The agent harness: the model/tool loop behind the in-process `openhuman` provider |
+| `vendor/tinyflows` | [`tinyhumansai/tinyflows`](https://github.com/tinyhumansai/tinyflows) | The DAG workflow engine behind the SDK's `flows` feature |
+| `vendor/tinyhumans-sdk` | [`tinyhumansai/sdk`](https://github.com/tinyhumansai/sdk) | The shared TinyHumans HTTP transport the direct backend client builds on |
+
+All three are self-contained: none declares a path or git dependency of its own,
+and none carries code submodules of its own.
+
+> This used to be a much longer page. Until v0.11.0 the runtime was an embedded
+> OpenHuman core at `vendor/openhuman`, which carried sixteen submodules of its
+> own — two of them a Tauri fork bundling CEF — and forced the root manifest to
+> reproduce that core's entire patch table rebased onto `vendor/openhuman/vendor/*`.
+> Removing the core removed all of it. See [Architecture](architecture.md).
+
 ## Initialize
 
 ```sh
-make init                      # runs the script below, plus tooling and hooks
-bash scripts/init-submodules.sh
+make init                          # the script below, plus tooling, deps and hooks
+bash scripts/init-submodules.sh    # submodules only
 ```
 
-Use the script, never `git submodule update --init --recursive`.
-`vendor/openhuman` has submodules of its own, and two of them
-(`app/src-tauri/vendor/tauri-cef`, a Tauri fork bundling CEF, and
-`app/src-tauri/vendor/tauri-plugin-notification`) belong to the OpenHuman desktop
-app. `--recursive` clones both, and nothing in Medulla's graph references either:
-the Cargo workspace excludes `vendor/`, so `app/src-tauri` is not a member. The
-wiki documentation submodules and `tinycortex`'s own nested `tinyagents` copy are
-skipped for the same reason.
+Use the script rather than `git submodule update --init --recursive`.
+`vendor/tinyagents` carries a `wiki` documentation submodule that nothing here
+compiles, and `--recursive` descends unconditionally. That is the whole of the
+difference now, but the script is still the one place the vendored set is
+written down, and it must stay in lockstep with the root manifest's
+`[patch.crates-io]` table.
 
-A git dependency on OpenHuman would not help. Cargo updates git-dependency
-submodules recursively with no opt-out, which makes the CEF clone mandatory. The
-submodule plus an explicit init list is the only way to avoid it.
-
-The script initializes `vendor/openhuman` and then several of its own vendored
-crates: `tinyagents`, `tinybus`, `tinychannels`, `tinycortex`, `tinyflows`,
-`tinyhumans-sdk`, `tinymemory`, and `tinyplace`. `vendor/motosan-ai-oauth` is
-not a submodule — OpenHuman vendors it as a plain tracked directory, so it
-comes along with the `vendor/openhuman` checkout itself.
+The submodule URLs in `.gitmodules` are HTTPS, so CI clones them without a
+deploy key.
 
 ## How each dependency is declared
-
-There is exactly one submodule, `vendor/openhuman`
-([`tinyhumansai/openhuman`](https://github.com/tinyhumansai/openhuman)). Everything
-else vendored reaches the build through it.
-
-| Crate | Declared as |
-| --- | --- |
-| `openhuman` | path dependency on `vendor/openhuman`, `default-features = false`, never patched (it has no registry coordinate) |
-| `tinyhumans-sdk` | path dependency on `vendor/openhuman/vendor/tinyhumans-sdk`, for the same reason |
-| `medulla-link` | path dependency on `src/link`; it is ours and is not vendored |
-| `tinyagents`, `tinybus`, `tinychannels`, `tinycortex`, `tinycortex-api`, `tinyflows`, `tinymemory`, `tinyplace`, `motosan-ai-oauth` | registry coordinates redirected by `[patch.crates-io]` to `vendor/openhuman/vendor/*` |
 
 Declare each vendored crate exactly one way: either as a direct path dependency
 or as a registry coordinate redirected by the patch table, and never both for the
 same crate. Mixing the two styles yields two `PackageId`s for one crate and an
-`E0308` where the types look identical, the first time a value crosses the
-Medulla and OpenHuman seam. Guard with `cargo tree -d`, which must report no
-duplicate `tiny*`.
+`E0308` where the types look identical, the first time a value crosses the seam.
 
-## The root patch table is load-bearing
+| Crate | Declared as |
+| --- | --- |
+| `tinyagents` | registry coordinate `"2.1"` with `features = ["sqlite", "tools"]`, redirected by `[patch.crates-io]` to `vendor/tinyagents` |
+| `tinyflows` | registry coordinate `"0.8"` with `features = ["mock", "host-caps", "store"]`, redirected by `[patch.crates-io]` to `vendor/tinyflows` |
+| `tinyhumans-sdk` | plain path dependency on `vendor/tinyhumans-sdk`; it has no registry coordinate, so there is nothing to patch |
+| `medulla-link` | path dependency on `src/link`; it is ours and is not vendored |
 
-`[patch.crates-io]` applies only from the workspace root. Once OpenHuman is a
-path dependency, its own patch table is ignored, as is
-`vendor/openhuman/vendor/tinycortex/.cargo/config.toml`, which is CWD-scoped.
-This workspace's root manifest therefore reproduces OpenHuman's entire table with
-paths rewritten to `vendor/openhuman/vendor/*`. Drop an entry and Cargo quietly
-resolves the published crate instead of the vendored tree rather than failing.
+Neither `tinyagents` feature is on by default in the crate. `sqlite` brings the
+durable session store (`tinyagents::session`) that backs the agent's per-thread
+transcript history; `tools` brings the builtin tool family the agent loop
+dispatches. `tinyflows`'s `mock` is a normal dependency feature rather than a
+dev-only one: the authoring surface dry-runs graphs against the engine's
+deterministic capability stand-ins in ordinary builds, not just in tests.
 
-Keep the table in lockstep with `scripts/init-submodules.sh`.
+Guard the result with two commands:
 
-The `tinyplace` entry stays even though no crate in this workspace links
-`tinyplace` any more: the vendored OpenHuman core still does, and without the
-redirect Cargo would resolve the published crate.
-
-One entry from OpenHuman's table is deliberately not copied, its `whisper-rs-sys`
-git patch. Cargo fetches a git patch source during resolution even when the
-patched crate is absent from the graph, which would put a network fetch in the
-critical path of every `--offline` build and of the `--network none` end-to-end
-image. Medulla never enables OpenHuman's `inference` feature, so `whisper-rs` is
-not in the graph.
-
-Verify the result with `cargo tree -i tinyagents`: the source must read
-`path+file://...`, never `registry+...`.
-
-## The OpenHuman feature set
-
-`openhuman` is declared `default-features = false` with the `medulla` feature
-enabled, and both halves of that matter.
-
-Turning defaults off is load-bearing rather than tidiness. OpenHuman's defaults
-include its own `tui` gate on ratatui 0.30 and crossterm 0.29 against this
-workspace's 0.29 and 0.28. Those are semver-incompatible at 0.x, so Cargo would
-link both: two raw-mode state machines and two background reader threads on one
-tty file descriptor. That is not a compile error, it is a wrecked terminal.
-
-An empty feature list would compile a core with no Medulla domain at all.
-`openhuman::medulla` and the `embed::Medulla` facade both sit behind the
-`medulla` gate, so without it the embedded core builds fine and has nothing this
-host can call.
-
-The core is not optional. It is the runtime this SDK hosts; a build without it
-has no runtime to offer but the offline mock.
-
-## `tinyflows`
-
-`tinyflows` is the DAG workflow engine behind the SDK's `workflows` feature. It
-is declared in the root `Cargo.toml` as a registry dependency and redirected to
-the vendored tree:
-
-```toml
-[workspace.dependencies]
-tinyflows = { version = "0.6", features = ["mock"] }
-
-[patch.crates-io]
-tinyflows = { path = "vendor/openhuman/vendor/tinyflows" }
+```sh
+cargo tree -d                 # must report no duplicate tiny*
+cargo tree -i tinyagents      # source must read path+file://…, never registry+…
 ```
 
-This is the same shape the sibling `openhuman` host uses. Keeping the registry
-coordinate rather than a bare path dependency means the two hosts share one pin
-and one upgrade cadence.
+## The root patch table
 
-The `mock` feature is a normal dependency feature, not a dev-only one: the
-authoring surface dry-runs graphs against the engine's deterministic capability
-stand-ins in ordinary builds, not just in tests.
+`[patch.crates-io]` applies only from the workspace root, so every vendored crate
+that also has a registry coordinate must be redirected there. Today that is two
+entries:
 
-Because `tinyflows` is pre-1.0 and still changing its `engine` entry points,
-expect the adapter seam in [`src/sdk/src/flow_engine/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/flow_engine/)
-to need attention on an update; the rest of the SDK should not.
+```toml
+[patch.crates-io]
+tinyagents = { path = "vendor/tinyagents" }
+tinyflows  = { path = "vendor/tinyflows" }
+```
+
+Dropping an entry does not fail loudly. Both crates are published, so Cargo
+quietly resolves the registry copy instead of the vendored tree and the build
+succeeds against the wrong code. Keep the table in lockstep with
+`scripts/init-submodules.sh`.
 
 ## Pins and upgrades
-
-When the two repositories disagree on a shared pin, the newer pin wins and the
-bump lands in OpenHuman. Adopting an older OpenHuman pin wholesale is a hard
-compile break (for example, a `tinyplace` ancestor missing `signal::maintain`,
-which `src/sdk/src/daemon/transport/mod.rs` calls), so advance the pin in
-OpenHuman and let this gitlink follow rather than patching around it here.
 
 To move a vendored crate forward:
 
 ```sh
-cd vendor/openhuman/vendor/tinyflows
+cd vendor/tinyflows
 git fetch origin
 git checkout <new-sha>
-cd ../../../..
+cd ../..
 cargo build            # confirm the adapter seam still compiles
 cargo test
 ```
 
 Then commit the gitlink.
 
-OpenHuman must never depend on the `medulla` crate. Its default-on
-`medulla-local` feature currently has an empty dependency list. The day someone
-gives it a real edge, `medulla-public` to `openhuman` to `medulla` becomes a
-Cargo dependency cycle and a hard failure.
+Because `tinyflows` is pre-1.0 and still changing its `engine` entry points,
+expect the adapter seam in
+[`src/sdk/src/flow_engine/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/flow_engine/)
+to need attention on an update; the rest of the SDK should not. `tinyagents`
+upgrades surface in [`src/sdk/src/agent/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/agent/),
+and `tinyhumans-sdk` upgrades in
+[`src/sdk/src/client/`](https://github.com/tinyhumansai/medulla-src/tree/main/src/sdk/src/client/).
 
 ## Coverage and the vendored tree
 
 Coverage excludes the vendored tree. `vendor/` path dependencies are local
 packages under the workspace root, so `cargo-llvm-cov`'s default registry filter
 does not drop them; the gate's `--ignore-filename-regex` starts with
-`(^|/)vendor/` for that reason. Removing it would measure the embedded OpenHuman
-core instead of this repository, and the gate would report roughly the
-first-party share of a very large tree. See [Testing](testing.md#coverage).
+`(^|/)vendor/` for that reason. Removing it would measure three upstream crates
+instead of this repository. See [Testing](testing.md#coverage).
 
 ## Read next
 
+* [Architecture](architecture.md): where each vendored crate sits in the runtime.
 * [Getting Started](getting-started.md): building from source.
 * [Contributing](contributing.md): the development loop and release process.
 * [Testing](testing.md): the suites and the coverage gate.

--- a/gitbooks/developers/vendoring.md
+++ b/gitbooks/developers/vendoring.md
@@ -14,7 +14,7 @@ repository's CI gates.
 | Submodule | Upstream | What it is |
 | --- | --- | --- |
 | `vendor/tinyagents` | [`tinyhumansai/tinyagents`](https://github.com/tinyhumansai/tinyagents) | The agent harness: the model/tool loop behind the in-process `openhuman` provider |
-| `vendor/tinyflows` | [`tinyhumansai/tinyflows`](https://github.com/tinyhumansai/tinyflows) | The DAG workflow engine behind the SDK's `flows` feature |
+| `vendor/tinyflows` | [`tinyhumansai/tinyflows`](https://github.com/tinyhumansai/tinyflows) | The DAG workflow engine behind the SDK's `workflows` feature |
 | `vendor/tinyhumans-sdk` | [`tinyhumansai/sdk`](https://github.com/tinyhumansai/sdk) | The shared TinyHumans HTTP transport the direct backend client builds on |
 
 All three are self-contained: none declares a path or git dependency of its own,

--- a/gitbooks/features/routing.md
+++ b/gitbooks/features/routing.md
@@ -98,11 +98,11 @@ failing the task, while surfacing every other failure immediately.
 ## Runtime selection
 
 Separately from model routing, the terminal app picks how it talks to an
-orchestrator at all, and reports in the status line why. It runs on an OpenHuman
-core embedded in the same process, so there is no server to reach and nothing to
-attach to. `--mock` selects a scripted offline runtime instead, and a core that
-boots with nobody signed in takes that same offline runtime rather than pretending
-to be live.
+orchestrator at all, and reports in the status line why. By default it drives the
+Medulla backend directly over the network, with no embedded core and no socket
+in between. `--mock` selects a scripted offline runtime instead, and a host with
+no backend configured or nobody signed in takes that same offline runtime rather
+than pretending to be live.
 
 [Configuration](../developers/configuration.md#runtimes) covers the selection
 rules and their edge cases.

--- a/gitbooks/features/workers-and-sessions.md
+++ b/gitbooks/features/workers-and-sessions.md
@@ -48,10 +48,10 @@ another. A registered machine is also a host in the chain, so it appears on the
 default survives a restart.
 
 Fleet peer management and task steering require a runtime that exposes a worker
-surface, meaning the hosted backend wired to a live hub, or the local core
-runtime, covered in [Configuration](../developers/configuration.md#runtimes). Without one,
-worker management reports itself unavailable rather than silently mutating
-unrelated state.
+surface, meaning the hosted backend wired to a live hub — see
+[Configuration](../developers/configuration.md#runtimes). Without one, worker
+management reports itself unavailable rather than silently mutating unrelated
+state.
 
 ### Seeing the whole fleet
 
@@ -222,16 +222,11 @@ strip above the lane list shows them with their running-task and attention
 badges, `^↑↓` walks between them, and clicking one switches. `/resume` picks up
 an earlier session, and `/abort` stops the running cycle.
 
-Against a local orchestration server this is single-threaded by construction,
-because that wire is one session per connection, so `/new` clears the view rather
-than opening a second thread.
-
 ### What survives
 
-Sessions are durable, and how durable depends on how you run Medulla. Against the
-backend, sessions persist server-side, so history and the event record replay on
-reconnect and a live session streams over SSE. Against a local core runtime,
-session state is persisted on disk under the state directory.
+Sessions are durable. They persist server-side, so history and the event record
+replay on reconnect and a live session streams over SSE — a session was never
+local state, which is why the client fetches one rather than owning one.
 
 Medulla can also run detached from the terminal app, so an operation and its
 event log survive the TUI exiting or crashing. Reattaching picks the live session
@@ -276,6 +271,22 @@ cache share when the provider reports one. A reading that was never reported is
 omitted rather than drawn at zero, so an empty bar always means a real zero. The
 rail shows what is *running* and nothing else; the declared fleet lives on the
 Hosts tab. Under the transcript is the composer.
+
+Nothing caps how many sessions you keep open. Each one runs on its own
+pseudo-terminal with its own terminal-emulator state, maintained in the
+background whether or not it is the row you are looking at, so selecting a
+different row shows a screen that is already current rather than one that has to
+catch up. Background sessions paint; they just do not receive input.
+
+That is also why you do not have to watch them. Medulla reads every backgrounded
+session's own screen for the signals that mean it wants a human — a startup
+dialog, a permission prompt, a numbered menu or a bare `(y/n)`, a blocking error,
+a terminal bell, a session that has died, a turn that finished and is waiting on
+review, or a harness's own notification hook firing — and rolls them into one
+`⚠` on the row plus a count in the rail's title:
+`Sessions · 12 · 9 running · ⚠ 3 waiting on you`. A fleet you are not watching
+still tells you when it needs you, which is the part a terminal multiplexer
+cannot do for you.
 
 `Ctrl-T` opens a session from any row: pick what to start, pick a directory,
 and it is running. The list offers this machine's coding CLIs and any harness

--- a/gitbooks/why-an-orchestrator-model.md
+++ b/gitbooks/why-an-orchestrator-model.md
@@ -1,8 +1,16 @@
 # Why an Orchestrator
 
-Agent harnesses like [Claude Code](https://www.anthropic.com/claude-code) and [Codex](https://github.com/openai/codex) are very good at running one task deeply. Orchestration is a different job, and the usual way of reaching for it is to point a harness at other harnesses: one more chat session, driving the rest.
+Agent harnesses like [Claude Code](https://www.anthropic.com/claude-code) and [Codex](https://github.com/openai/codex) are very good at running one task deeply. Orchestration is a different job, and there are two usual ways of reaching for it. Split the terminal — tmux, a pane each — and drive them yourself. Or point a harness at other harnesses: one more chat session, driving the rest.
 
-That works for three or four. It stops working past that, and it stops working for reasons that have nothing to do with how capable the model is.
+Both work for three or four. Both stop working past that, and neither stops for reasons that have anything to do with how capable the model is.
+
+## The terminal multiplexer was never the answer
+
+tmux solves a real problem, and it is not this one. It gives you panes; it has no idea what is in them. Which agent is blocked on a permission prompt, which one died twenty minutes ago, which one is finished and waiting for you to look — a multiplexer cannot tell you, because to it they are all just bytes on a pseudo-terminal. You are the scheduler. You cycle the panes, you read them, you notice. That is a job that scales linearly with the number of agents and holds for about as long as your attention does.
+
+Medulla runs the same processes, on the same kind of PTY, and reads them. Every session it opens has its own terminal emulator kept live in the background whether or not you are looking at it, and Medulla watches all of them for the things that actually need you: a permission prompt, a startup dialog, a blocking error, a terminal bell, a session that died, a turn that finished and is waiting on review. Those roll up to one mark per row and one count in the rail's title — *`⚠ 3 waiting on you`* — so a fleet you are not watching still tells you when it needs you.
+
+That is the difference in one line. A multiplexer gives you N things to check. Medulla tells you which of the N to look at, and puts you there in a keystroke.
 
 ## The shape mismatch
 
@@ -49,6 +57,12 @@ Handed five repositories and a fleet of harnesses, a model with no other informa
 Medulla separates deciding from doing. The orchestrator tier holds the operation: it decides what happens next, reads the distilled picture of the fleet, funds and reviews delegations. It does not fan out itself. Each cycle it deploys 0..N concurrent managers, fixing each manager's host and workspace for that manager's whole run, and each manager then chooses the harness, targets or spawns agents, and delegates tasks to them.
 
 That split is what keeps the top of the stack narrow. The orchestrator tier is deliberately the smallest surface in the system: it never reads raw fleet traffic, and it does not even see the reasoning tier's scratch tools. Delegation is also detached, so a delegation returns immediately and the operation continues rather than blocking until the fan-out drains.
+
+## Neither, then
+
+The two workarounds fail from opposite ends. The multiplexer knows nothing about the work, so you supply all the judgement. The chat-shaped orchestrator supplies judgement but drowns in the traffic, because every agent it manages writes into the one transcript it thinks with.
+
+Medulla is the third option: a process built to hold an operation — a registry of live sessions with no fixed ceiling, a ledger that makes every task settle, explicit caps on fan-out and spend, and a reasoning surface deliberately kept small enough to stay accurate while the fleet grows. You open another agent with `Ctrl-T`. Nothing about the twentieth is different from the second.
 
 ## Read next
 

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ sha256_of() {
 
 # ---- Platform detection ------------------------------------------------------
 # Keys match the release build matrix's Rust target triples (see
-# src/sdk/src/update.rs::platform_key).
+# src/sdk/src/update/check.rs::platform_key).
 
 detect_target() {
     os="$(uname -s)"


### PR DESCRIPTION
The docs, gitbooks and installers were split out of `medulla-src` on 24 Aug and have not been updated since — which is exactly when the embedded OpenHuman core was removed. Nearly every developer page still described an architecture that no longer exists: an embedded core owning the runtime, the credential store, the workflow wire types and the vendored dependency graph.

26 files. Every claim was re-derived from `medulla-src` at v0.11.1. `scripts/check-public-boundary.sh` passes; all relative links and heading anchors resolve.

## Pages that were wrong, not merely stale

**`developers/vendoring.md` and `docs/vendoring.md`** — full rewrites. Both documented a `vendor/openhuman` submodule carrying sixteen nested submodules (including a Tauri fork bundling CEF) and a ten-entry patch table that had to be kept in lockstep by hand. Reality is three self-contained crates — `tinyagents`, `tinyflows`, `tinyhumans-sdk` — and a two-entry patch table. The old page also gave `tinyflows` as `0.5` at a commit that is no longer the pin, claimed `tinyagents` arrives transitively through `tinycortex` when it is now a direct submodule, and never mentioned `tinyhumans-sdk` at all.

**`developers/authentication.md`** — rewritten. The page said the session lives in the embedded core's credential store, "the OS keychain where one is available". There is no keychain code anywhere in `auth/`. The session is a `0600` `session.json` under the per-account home, written to a temp file and renamed, with the `active_user.toml` marker published only after it lands. Now documents the real precedence chain (`backend.token` → `backend.tokenEnv` → stored session), issuer-scoped sessions, the login/logout refusals and their exact messages, and account-id sanitization.

It also had the legacy-credentials behaviour backwards: `login` **adopts** a retired `credentials.json` (verifies its JWT, rewrites it as a session, removes the old file only afterwards) and only `logout` deletes one — because leaving one at logout would sign the operator straight back in on next launch.

**`developers/architecture.md`, `sdk.md`, `configuration.md`, `cli-reference.md`, `the-tui.md`, `troubleshooting.md`, `glossary.md`, `harness-integration.md`, `features/routing.md`, `getting-started.md`, `contributing.md`** — `cloud`/`mock` runtimes in place of the core, the in-process `openhuman` provider on `tinyagents`, the `hub/plane` wire contract, and three crates rather than two. `sdk.md` was documenting `OpenHumanRuntime::new(core)`, a type that no longer exists, and claimed the HTTP/SSE runtime had been removed when it is in fact the current one.

Also corrected: `configuration.md`'s Medulla-home listing invented a `chats/` directory and a `.openhuman/` state dir; `troubleshooting.md` told people to press `m` on the login screen for the mock runtime, which `ui/login/types.rs` explicitly refuses to offer; `cli-reference.md` documented three daemon flags (`--handle`, `--skills`, `--no-onboard`) that are accepted but never read.

**`developers/environment-variables.md`** — added the agent-turn environment scrubbing, including the deliberate over-reach that `SSH_AUTH_SOCK` contains `AUTH`, so a shelled command cannot reach the operator's ssh-agent and a `git push` over SSH from inside a turn will not authenticate.

**`docs/workspace-profiles.md`** — deleted the "Model resolution" section. `medulla init` has not called a model since the memory layer went; `InitOutcome::drafted` is always false and `--offline` is now the only behaviour rather than a choice.

## New material

`glossary.md` gains entries for `CloudRuntime`, `runtime::cloud::connect` / `Readiness`, the hub plane, the app session and account marker, `tinyagents`, the local provider, `HarnessProvider::Shell` and the harness wrappers. `harness-integration.md` gains a Providers section covering all five `HarnessProvider` values. `docs/TERMINOLOGY.md` gains the in-process harness and `hub/plane`.

## Positioning

`README.md`, `gitbooks/README.md` and `why-an-orchestrator-model.md` now name the thing Medulla replaces: tmux and the multi-agent wrappers. The claim is kept to what the code backs — an unbounded session registry, each session's emulator state kept live in the background, and the attention scraper rolling permission prompts, blocking errors, bells, dead sessions and finished-turns-awaiting-review into `⚠ 3 waiting on you`.

Deliberately **not** claimed: a simultaneous multi-pane grid. It is a rail plus one live pane, and the docs say so.

## Left for a human

`README.md` and `pricing-and-availability.md` both say access is rolling out to "a small group of OpenHuman subscribers first". That is a business statement rather than a code claim, so it may well still be true — but it now reads oddly against the architecture. Flagging rather than rewording.

The companion PR in `tinyhumansai/medulla-src` fixes the in-repo module READMEs, doc comments and `config.example.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented running multiple agents concurrently in one terminal, with independent live sessions and aggregated attention notifications.
  * Updated architecture and workflow documentation to describe direct backend connectivity over HTTP.
  * Added guidance for new `openhuman` and shell providers, including their selection and capabilities.
  * Clarified authentication, session storage, credential precedence, and logout behavior.
  * Added documentation for the `medulla skills` command and slash commands.
  * Updated vendoring, configuration, troubleshooting, environment variables, and development guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->